### PR TITLE
Add More Sites and Improve the Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ---
 
 ### Needed Components:
-You will need to install all of these before downloading any (legitimate or pirated) games to stop crashing due to missing software on your computer:
+You must install all of these before downloading any (legitimate or pirated) games to stop crashing due to missing software on your computer:
 
 - [DirectX](https://www.microsoft.com/download/details.aspx?id=35)
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
@@ -18,21 +18,8 @@ You will need to install all of these before downloading any (legitimate or pira
 - [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
 - [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
-### Torrent Sites:
-You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
-
-- [1337x](https://1337x.to/cat/Games/1) - Do not download torrents uploaded by IGG Games.
-- [Mac Torrents](https://www.torrentmac.net/category/games)
-- [Mac Torrent](https://www.mactorrents.is/macos-games)
-- [NMac](https://nmac.to/category/games)
-- [RARBG](https://rarbgproxied.org/torrents.php?category=2;27;28;29;30;31;53)
-- [Rutor](http://rutor.info/games)
-- [RuTracker](https://rutracker.org/forum/index.php?c=19)
-- [Rustorka](https://rustorka.com/forum)
-- [Tapochek](https://tapochek.net)
-
 ### Direct Download Sites:
-Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, ZippyShare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
+Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, Zippyshare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
 - [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For cracked iOS apps and games.
 - [AppKed](https://www.macbed.com/games)
@@ -63,15 +50,18 @@ Direct downloads are any normal download: You download the file from a server th
 - [Torrminatorr Forum](https://forum.torrminatorr.com)
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs.
 
-### Trainers (Cheats):
-Note: These are not for online games. Do not use cheats in online games!
+### Torrent Sites:
+You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
-- [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
-- [FLiNG Trainer](https://flingtrainer.com)
-- [GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
-- [MegaGames](https://megagames.com)
-- [MrAntiFun](https://mrantifun.net)
-- [WeMod](https://www.wemod.com)
+- [1337x](https://1337x.to/cat/Games/1) - Do not download torrents uploaded by IGG Games.
+- [Mac Torrents](https://www.torrentmac.net/category/games)
+- [Mac Torrent](https://www.mactorrents.is/macos-games)
+- [NMac](https://nmac.to/category/games)
+- [RARBG](https://rarbgproxied.org/torrents.php?category=2;27;28;29;30;31;53)
+- [Rutor](http://rutor.info/games)
+- [RuTracker](https://rutracker.org/forum/index.php?c=19)
+- [Rustorka](https://rustorka.com/forum)
+- [Tapochek](https://tapochek.net)
 
 ### Repacks:
 Repacks are highly compressed games, designed for people with limited and/or slow internet bandwidth. You must install them on your computer once you download them, which can take a long time due to file decompression.
@@ -99,6 +89,16 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [Xatab](https://byxatab.com)
 - ZAZIX
 
+### Trainers (Cheats):
+Note: These are not for online games. Do not use cheats in online games!
+
+- [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
+- [FLiNG Trainer](https://flingtrainer.com)
+- [GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
+- [MegaGames](https://megagames.com)
+- [MrAntiFun](https://mrantifun.net)
+- [WeMod](https://www.wemod.com)
+
 ### Release Networks:
 Note: None of these sites provide downloads, only information on P2P and/or scene releases. Looking to see if a game is cracked? Check here!
 
@@ -120,14 +120,48 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Edge Emulation](https://edgeemu.net)
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
 - [NXBrew](https://nxbrew.com)
-- [The Eye](https://the-eye.eu)
-- [The ROM Depot](https://theromdepot.com)
 - [RomUlation](https://www.romulation.net)
 - [r/Roms](https://www.reddit.com/r/roms)
 - [r/Roms Megathread](https://r-roms.github.io)
 - [ROMSPURE](https://romspure.cc)
+- [The Eye](https://the-eye.eu)
+- [The ROM Depot](https://theromdepot.com)
 - [Vimm's Lair](https://vimm.net/?p=vault)
 - [Ziperto](https://www.ziperto.com)
+
+### Direct Downloading Software:
+
+- [Free Download Manager](https://www.freedownloadmanager.org)
+- [Internet Download Manager](https://internetdownloadmanager.com)
+- [JDownloader2](https://jdownloader.org/jdownloader2)
+- [Motrix](https://motrix.app)
+- [pyLoad](https://pyload.net)
+- [Xtreme Download Manager](https://xtremedownloadmanager.com)
+
+### Torrent Software:
+
+- [BiglyBT](https://www.biglybt.com)
+- [Deluge](https://dev.deluge-torrent.org)
+- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
+- [PicoTorrent](https://picotorrent.org)
+- [qBittorrent](https://www.qbittorrent.org)
+- [Tixati](https://tixati.com)
+- [Transmission](https://transmissionbt.com)
+- [WebTorrent](https://webtorrent.io)
+
+### Tools:
+
+- [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically set your game up for CreamAPI.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatically create Steamworks fixes.
+- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Unlock pirated DLCs on legitimate Steam games.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
+- [Lucky Patcher](https://www.luckypatchers.com) - Patch Android apps (better with root).
+- [LumaPlay (for Uplay)](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197)
+- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551)
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412)
+- [RIN SteamInternals - A Broad Collection of Steam Tools](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887)
+- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Updater tool for pirated The Sims 4 version.
+- [Steamless](https://github.com/atom0s/Steamless)
 
 ### Emulators:
 
@@ -155,40 +189,6 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Yuzu](https://yuzu-emu.org) - For Nintendo Switch games.
 - [ZSNES](https://zsnes.com) - For Super Nintendo Entertainment System games.
 
-### Torrent Software:
-
-- [BiglyBT](https://www.biglybt.com)
-- [Deluge](https://dev.deluge-torrent.org)
-- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
-- [PicoTorrent](https://picotorrent.org)
-- [qBittorrent](https://www.qbittorrent.org)
-- [Tixati](https://tixati.com)
-- [Transmission](https://transmissionbt.com)
-- [WebTorrent](https://webtorrent.io)
-
-### Direct Downloading Software:
-
-- [Free Download Manager](https://www.freedownloadmanager.org)
-- [Internet Download Manager](https://internetdownloadmanager.com)
-- [JDownloader2](https://jdownloader.org/jdownloader2)
-- [Motrix](https://motrix.app)
-- [pyLoad](https://pyload.net)
-- [Xtreme Download Manager](https://xtremedownloadmanager.com)
-
-### Tools:
-
-- [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically set your game up for CreamAPI.
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatically create Steamworks fixes.
-- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Unlock pirated DLCs on legitimate Steam games.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
-- [Lucky Patcher](https://www.luckypatchers.com) - Patch Android apps (better with root).
-- [LumaPlay (for Uplay)](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197)
-- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551)
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412)
-- [RIN SteamInternals - A Broad Collection of Steam Tools](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887)
-- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Updater tool for pirated The Sims 4 version.
-- [Steamless](https://github.com/atom0s/Steamless)
-
 ### Useful Software:
 
 - [7-Zip](https://7-zip.org)
@@ -199,7 +199,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Tor Browser](https://www.torproject.org)
 - [WinRAR](https://www.rarlab.com)
 
-**You can use [MAS](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
+**Use [MAS](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
 
 **Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
 
@@ -214,13 +214,6 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/r/VPN/comments/m736zt/vpn_comparison_table)
 
 **Tor is NOT a VPN, it will not protect you when torrenting!**
-
-### Unsafe Software:
-
-- μTorrent - Same as Bittorrent: Has ads and trackers and are unsafe.
-- Avast - Notorious for collecting and selling user data.
-- Bittorrent - Same as μTorrent: Has ads and trackers and is unsafe.
-- CCleaner - Owned by Avast.
 
 ### Untrusted Sites and Uploaders:
 
@@ -249,3 +242,10 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - Worldofpcgames - Malicious downloads.
 - xGIROx - Repacks contain bitcoin miners.
 - Any site with a scene group name in the URL - **SCENE GROUPS DO NOT HAVE SITES!**
+
+### Unsafe Software:
+
+- μTorrent - Same as Bittorrent: Has ads and trackers and are unsafe.
+- Avast - Notorious for collecting and selling user data.
+- Bittorrent - Same as μTorrent: Has ads and trackers and is unsafe.
+- CCleaner - Owned by Avast.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You will likely need a VPN to download torrents to avoid receiving copyright not
 - [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
 - [NMac](https://nmac.to/category/games) - For macOS apps and games.
-- [RARBG](https://rarbgproxied.org/torrents.php?category=2;27;28;29;30;31;53)
+- [RARBG](https://rarbg.to)
 - [Rutor](http://rutor.info/games)
 - [RuTracker](https://rutracker.org/forum/index.php?c=19)
 - [Rustorka](https://rustorka.com/forum)

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ You will need to install all of these before downloading any (legitimate or pira
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
 - [1337x](https://1337x.to) - Do not download torrents uploaded by IGGGames.
+- [Mac Torrents](https://www.torrentmac.net)
+- [Mac Torrent](https://www.mactorrents.is)
 - [NMac](https://nmac.to)
 - [RARBG](https://rarbg.to)
-- [RuTor](http://rutor.info)
+- [Rutor](http://rutor.info)
 - [RuTracker](https://rutracker.org)
 - [Rustorka](https://rustorka.com/forum)
 - [Tapochek](https://tapochek.net)
@@ -91,24 +93,23 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 ### Release Networks:
 Note: None of these sites provide downloads, only information on P2P and/or scene releases. Looking to see if a game is cracked? Check here!
 
-- [CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer "When will X game be cracked?" question.
-- [CrackWatch](https://www.reddit.com/r/CrackWatch)
+- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer "When will X game be cracked?" question.
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [m2v.ru](https://m2v.ru)
-- [PreDB.de](https://predb.de)
+- [PreDB.de](https://predb.de/section/GAMES)
 - [PreDB.me](https://predb.me/?cats=games-pc)
-- [PreDB.org](https://predb.org)
-- [PreDB.ovh](https://predb.ovh)
+- [PreDB.org](https://predb.org/cats/GAMES)
 - [PreDB.pw](https://predb.pw)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 - [srrDB](https://www.srrdb.com)
-- [xREL](https://xrel.to)
+- [xREL](https://www.xrel.to/games-release-list.html)
 
 ### ROM Sites:
 
 - [CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [Emuparadise](https://www.emuparadise.me) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
 - [NXBrew](https://nxbrew.com)
 - [The Eye](https://the-eye.eu)
 - [The ROM Depot](https://theromdepot.com)
@@ -167,8 +168,8 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Tools:
 
-- [Auto CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically set your game up for CreamAPI.
-- [Auto Steamworks Fix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatically create Steamworks fixes.
+- [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically set your game up for CreamAPI.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatically create Steamworks fixes.
 - [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Unlock pirated DLCs on legitimate Steam games.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
 - [Lucky Patcher](https://www.luckypatchers.com) - Patch Android apps (better with root).
@@ -224,8 +225,8 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - NexusGames - Malicious downloads.
 - nosTEAM
 - Ocean of Games - High malware risk.
+- Qoob/Seyter - Repacks contain bitcoin miners.
 - Repack-Games - Mislabel games and steal releases.
-- Seyter - Repacks contain bitcoin miners.
 - Steam-Repacks - Malicious downloads.
 - The Pirate Bay - Malware risk.
 - WIFI4Games - Malicious downloads.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [KAPITALSIN](https://kapitalsin.com/forum)
 - [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
-- [MagiPack Games](https://www.magipack.games)
 - Masquerade Repacks (moved to KaOsKrew)
 - Mr DJ
 - R.G. Catalyst

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Direct downloads are any normal download: You download the file from a server th
 
 - [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For cracked iOS apps and games.
 - [AppKed](https://www.macbed.com/games)
-- [Archive.org - Classic PC Games](https://archive.org/details/classicpcgames)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene games.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene uploads.
 - [CS.RIN.RU](https://cs.rin.ru/forum)
@@ -48,6 +47,7 @@ Direct downloads are any normal download: You download the file from a server th
 - [GamesDrive](https://gamesdrive.net)
 - [GLOAD](https://gload.to)
 - [GOG Games](https://gog-games.com)
+- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames)
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
@@ -55,7 +55,7 @@ Direct downloads are any normal download: You download the file from a server th
 - [Ova Games](https://www.ovagames.com)
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
-- [Seven Gamers](https://www.seven-gamers.com) - 
+- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive (locked behind a password only available for members of their Discord server for at least one day) and torrent links.
 - [SKlauncher](https://skmedix.pl) - For Minecraft.
 - [SteamRIP](https://steamrip.com)
 - [Torrminatorr Forum](https://forum.torrminatorr.com)

--- a/README.md
+++ b/README.md
@@ -21,29 +21,30 @@ You will need to install all of these before downloading any (legitimate or pira
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
-- [1337x](https://1337x.to) - Do not download torrents uploaded by IGGGames.
-- [Mac Torrents](https://www.torrentmac.net)
-- [Mac Torrent](https://www.mactorrents.is)
-- [NMac](https://nmac.to)
-- [RARBG](https://rarbg.to)
-- [Rutor](http://rutor.info)
-- [RuTracker](https://rutracker.org)
+- [1337x](https://1337x.to/cat/Games/1) - Do not download torrents uploaded by IGG Games.
+- [Mac Torrents](https://www.torrentmac.net/category/games)
+- [Mac Torrent](https://www.mactorrents.is/macos-games)
+- [NMac](https://nmac.to/category/games)
+- [RARBG](https://rarbgproxied.org/torrents.php?category=2;27;28;29;30;31;53)
+- [Rutor](http://rutor.info/games)
+- [RuTracker](https://rutracker.org/forum/index.php?c=19)
 - [Rustorka](https://rustorka.com/forum)
 - [Tapochek](https://tapochek.net)
 
 ### Direct Download Sites:
 Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, ZippyShare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
-- [AppCake](https://iphonecake.com) - For cracked iOS apps and games.
-- [AppKed](https://www.macbed.com)
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For cracked iOS apps and games.
+- [AppKed](https://www.macbed.com/games)
 - [Archive.org - Classic PC Games](https://archive.org/details/classicpcgames)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene games.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - For CrackHub213's scene uploads.
+- [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene uploads.
 - [CS.RIN.RU](https://cs.rin.ru/forum)
 - [DOS Games Archive](https://www.dosgamesarchive.com)
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
 - [G4U](https://g4u.to)
 - [Game-2U](https://game-2u.com) - For PlayStation 4 games (use the [FastForward](https://fastforward.team/install) browser extension to bypass ad shortlinks).
+- [GameDrive](https://gamedrive.org)
 - [GamesDrive](https://gamesdrive.net)
 - [GLOAD](https://gload.to)
 - [GOG Games](https://gog-games.com)
@@ -52,8 +53,9 @@ Direct downloads are any normal download: You download the file from a server th
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Online Fix](https://online-fix.me) - For online multiplayer games.
 - [Ova Games](https://www.ovagames.com)
-- [RLSBB](https://rlsbb.ru)
-- [Scnlog](https://scnlog.me)
+- [ReleaseBB](https://rlsbb.ru/category/games)
+- [Scnlog](https://scnlog.me/games)
+- [Seven Gamers](https://www.seven-gamers.com) - 
 - [SKlauncher](https://skmedix.pl) - For Minecraft.
 - [SteamRIP](https://steamrip.com)
 - [Torrminatorr Forum](https://forum.torrminatorr.com)
@@ -64,6 +66,7 @@ Note: These are not for online games. Do not use cheats in online games!
 - [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
 - [FLiNG Trainer](https://flingtrainer.com)
 - [GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
+- [MegaGames](https://megagames.com)
 - [MrAntiFun](https://mrantifun.net)
 - [WeMod](https://www.wemod.com)
 
@@ -76,10 +79,13 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [Darck Repacks](https://darckrepacks.com)
 - [ElAmigos](https://elamigos.site)
 - [FitGirl Repacks](https://fitgirl-repacks.site)
+- [FluxyRepacks](https://www.fluxycrack.fr)
 - [Gnarly Repacks](https://gnarly-repacks.site)
 - [KaOsKrew](https://kaoskrew.org)
 - [KAPITALSIN](https://kapitalsin.com/forum)
+- [Leechinghell](http://www.leechinghell.pw)
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- [MagiPack Games](https://www.magipack.games)
 - Masquerade Repacks (moved to KaOsKrew)
 - Mr DJ
 - R.G. Catalyst
@@ -208,27 +214,34 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Unsafe Software:
 
-- μTorrent - Same as Bittorrent: Has ads and trackers and is unsafe.
+- μTorrent - Same as Bittorrent: Has ads and trackers and are unsafe.
 - Avast - Notorious for collecting and selling user data.
-- BitTorrent - Same as μTorrent: Has ads and trackers and is unsafe.
+- Bittorrent - Same as μTorrent: Has ads and trackers and is unsafe.
 - CCleaner - Owned by Avast.
 
 ### Untrusted Sites and Uploaders:
 
 - AGFY - Scam links.
+- AllTorrents
 - ApunKaGames
-- cracked-games - Malware risk.
+- cracked-games/GETGAMEZ - Malware risk.
 - CrackingPatching - Malware risk.
 - Downloadly - Contain crypto miners.
-- GOG Unlocked/SteamUnlocked - Malicious link redirects, slow downloads and uploads stolen from IGGGames.
-- IGGGAMES/PCGamesTorrents - They doxxed mercs213 (Good Old Downloads owner), exploit you for ad revenue and package their own DRM in indie games.
+- FreeTP
+- Game3rb
+- Games Releaser
+- GOG Unlocked/SteamUnlocked - Malicious link redirects, slow downloads and uploads stolen from IGG Games.
+- IGG Games/PCGamesTorrents - They doxed mercs213 (Good Old Downloads owner), exploit you for ad revenue and package their own DRM in indie games.
+- MrPcGames
 - NexusGames - Malicious downloads.
 - nosTEAM
 - Ocean of Games - High malware risk.
 - Qoob/Seyter - Repacks contain bitcoin miners.
 - Repack-Games - Mislabel games and steal releases.
 - Steam-Repacks - Malicious downloads.
+- Steam Cracked
 - The Pirate Bay - Malware risk.
+- Unlocked-Games
 - WIFI4Games - Malicious downloads.
 - Worldofpcgames - Malicious downloads.
 - xGIROx - Repacks contain bitcoin miners.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Direct downloads are any normal download: You download the file from a server th
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
-- [1337x](https://1337x.to/cat/Games/1) - Do not download torrents uploaded by IGG Games.
+- [1337x](https://1337x.to/cat/Games/1) - Avoid torrents uploaded by IGG Games.
 - [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
 - [NMac](https://nmac.to/category/games) - For macOS apps and games.
@@ -189,7 +189,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 ### Useful Software:
 
 - [7-Zip](https://7-zip.org) - File archiver.
-- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher)
+- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Achievement file parser that provides automatic screenshot, playtime tracking and real-time notification.
 - [Bitwarden](https://bitwarden.com) - Open source password manager.
 - [Parsec](https://parsec.app) - Play local multiplayer games from anywhere.
 - [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Checksum verifier and hash info generator.
@@ -201,8 +201,8 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Useful Browser Extensions:
 
-- [FastForward](https://fastforward.team)
-- [uBlock Origin](https://ublockorigin.com)
+- [FastForward](https://fastforward.team) - Link shorteners bypasser.
+- [uBlock Origin](https://ublockorigin.com) - Ad content blocker.
 
 ### VPNs:
 - [r/VPN](https://www.reddit.com/r/VPN)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Direct downloads are any normal download: You download the file from a server th
 - [CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
-- [G4U](https://g4u.to)
+- [G4U](https://g4u.to) - Slow downloads for free users.
 - [Game-2U](https://game-2u.com) - For PlayStation 4 games (use the [FastForward](https://fastforward.team/install) browser extension to bypass ad shortlinks).
 - [GameDrive](https://gamedrive.org)
 - [GamesDrive](https://gamesdrive.net)
@@ -68,8 +68,8 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 
 - [Chovka](https://repack.info)
 - [CPG Repacks](https://cpgrepacks.site)
-- [DODI Repacks](https://dodi-repacks.site)
 - [Darck Repacks](https://darckrepacks.com)
+- [DODI Repacks](https://dodi-repacks.site)
 - [ElAmigos](https://elamigos.site) - Slow downloads for free users, download via GLOAD or Ova Games instead.
 - [FitGirl Repacks](https://fitgirl-repacks.site)
 - [FluxyRepacks](https://www.fluxycrack.fr)
@@ -102,13 +102,13 @@ Note: These are not for online games. Do not use cheats in online games!
 ### Release Networks:
 Note: None of these sites provide downloads, only information on P2P and/or scene releases. Wanting to see if a game is cracked? Check here!
 
-- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer the "When will X game be cracked?" question.
-- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [m2v.ru](https://m2v.ru)
 - [PreDB.de](https://predb.de/section/GAMES)
 - [PreDB.me](https://predb.me/?cats=games-pc)
 - [PreDB.org](https://predb.org/cats/GAMES)
 - [PreDB.pw](https://predb.pw)
+- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer the "When will X game be cracked?" question.
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 - [srrDB](https://www.srrdb.com)
@@ -120,10 +120,10 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Edge Emulation](https://edgeemu.net)
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
-- [RomUlation](https://www.romulation.net)
 - [r/Roms](https://www.reddit.com/r/roms)
 - [r/Roms Megathread](https://r-roms.github.io)
 - [ROMSPURE](https://romspure.cc)
+- [RomUlation](https://www.romulation.net)
 - [The Eye](https://the-eye.eu)
 - [The ROM Depot](https://theromdepot.com)
 - [Vimm's Lair](https://vimm.net/?p=vault)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Direct downloads are any normal download: You download the file from a server th
 - [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames)
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
+- [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Online Fix](https://online-fix.me) - For online multiplayer games.
 - [Ova Games](https://www.ovagames.com)
@@ -58,7 +59,9 @@ Direct downloads are any normal download: You download the file from a server th
 - [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive (locked behind a password only available for members of their Discord server for at least one day) and torrent links.
 - [SKlauncher](https://skmedix.pl) - For Minecraft.
 - [SteamRIP](https://steamrip.com)
+- [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
 - [Torrminatorr Forum](https://forum.torrminatorr.com)
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs.
 
 ### Trainers (Cheats):
 Note: These are not for online games. Do not use cheats in online games!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Here is the /r/PiratedGames Megathread!** - [translations](translations)
+**Here is the /r/PiratedGames Megathread!** - [Translations](translations)
 ---
 
 ### Needed Components:
@@ -21,7 +21,7 @@ You will need to install all of these before downloading any (legitimate or pira
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
-- [1337x](https://1337x.to) - Do not download torrents uploaded by IGG Games.
+- [1337x](https://1337x.to) - Do not download torrents uploaded by IGGGames.
 - [NMac](https://nmac.to)
 - [RARBG](https://rarbg.to)
 - [RuTor](http://rutor.info)
@@ -30,25 +30,25 @@ You will likely need a VPN to download torrents to avoid receiving copyright not
 - [Tapochek](https://tapochek.net)
 
 ### Direct Download Sites:
-Direct downloads are any normal download: You download the file from a server through a web browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, ZippyShare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
+Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, ZippyShare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
 - [AppCake](https://iphonecake.com) - For cracked iOS apps and games.
 - [AppKed](https://www.macbed.com)
 - [Archive.org - Classic PC Games](https://archive.org/details/classicpcgames)
-- [CrackHub](https://crackhub.site) - For FitGirl repacks and scene games. 
+- [CrackHub](https://crackhub.site) - For FitGirl repacks and scene games.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For CrackHub213's scene uploads.
 - [CS.RIN.RU](https://cs.rin.ru/forum)
 - [DOS Games Archive](https://www.dosgamesarchive.com)
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
 - [G4U](https://g4u.to)
-- [Game-2U](https://game-2u.com) - For PS4 games (use the [FastForward extension](https://fastforward.team/install) to bypass ad shortlinks).
+- [Game-2U](https://game-2u.com) - For PlayStation 4 games (use the [FastForward](https://fastforward.team/install) browser extension to bypass ad shortlinks).
 - [GamesDrive](https://gamesdrive.net)
 - [GLOAD](https://gload.to)
 - [GOG Games](https://gog-games.com)
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
-- [Online Fix](https://online-fix.me) - For online multiplayer games. 
+- [Online Fix](https://online-fix.me) - For online multiplayer games.
 - [Ova Games](https://www.ovagames.com)
 - [RLSBB](https://rlsbb.ru)
 - [Scnlog](https://scnlog.me)
@@ -69,7 +69,7 @@ Note: These are not for online games. Do not use cheats in online games!
 Repacks are highly compressed games, designed for people with limited and/or slow internet bandwidth. You must install them on your computer once you download them, which can take a long time due to file decompression.
 
 - [Chovka](https://repack.info)
-- [CPG Repacks](https://cpgrepacks.site) 
+- [CPG Repacks](https://cpgrepacks.site)
 - [DODI Repacks](https://dodi-repacks.site)
 - [Darck Repacks](https://darckrepacks.com)
 - [ElAmigos](https://elamigos.site)
@@ -80,7 +80,7 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
 - Masquerade Repacks (moved to KaOsKrew)
 - Mr DJ
-- R.G. Catalyst 
+- R.G. Catalyst
 - R.G. Mechanics
 - R.G. Revenants
 - [Scooter Repacks](https://scooter-repacks.site)
@@ -128,7 +128,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Dolphin Emulator](https://dolphin-emu.org) - For Nintendo GameCube and Wii games.
 - [DuckStation](https://www.duckstation.org) - For PlayStation 1 games.
 - [ePSXe](https://epsxe.com) - For PlayStation 1 games.
-- [Kega Fusion](https://www.carpeludum.com/kega-fusion) - For Sega Genesis and Mega Drive games.
+- [Kega Fusion](https://www.carpeludum.com/kega-fusion) - For Sega Genesis/Mega Drive games.
 - [MAME](https://www.mamedev.org) - For arcade games.
 - [MelonDS](https://melonds.kuribo64.net) - For Nintendo DS games.
 - [mGBA](https://mgba.io) - For Game Boy Advance games.
@@ -158,10 +158,10 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Direct Downloading Software:
 
-- [Free Download Manager](https://www.freedownloadmanager.org) 
+- [Free Download Manager](https://www.freedownloadmanager.org)
 - [Internet Download Manager](https://internetdownloadmanager.com)
 - [JDownloader2](https://jdownloader.org/jdownloader2)
-- [Motrix](https://motrix.app) 
+- [Motrix](https://motrix.app)
 - [pyLoad](https://pyload.net)
 - [Xtreme Download Manager](https://xtremedownloadmanager.com)
 
@@ -219,7 +219,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - cracked-games - Malware risk.
 - CrackingPatching - Malware risk.
 - Downloadly - Contain crypto miners.
-- GOG Unlocked/SteamUnlocked - Malicious link redirects, slow downloads and uploads stolen from IGG Games.
+- GOG Unlocked/SteamUnlocked - Malicious link redirects, slow downloads and uploads stolen from IGGGames.
 - IGGGAMES/PCGamesTorrents - They doxxed mercs213 (Good Old Downloads owner), exploit you for ad revenue and package their own DRM in indie games.
 - NexusGames - Malicious downloads.
 - nosTEAM

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [FitGirl Repacks](https://fitgirl-repacks.site)
 - [FluxyRepacks](https://www.fluxycrack.fr)
 - [Gnarly Repacks](https://gnarly-repacks.site)
-- [KaOsKrew](https://kaoskrew.org)
+- [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [KAPITALSIN](https://kapitalsin.com/forum)
 - [Leechinghell](http://www.leechinghell.pw)
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ You must install all of these before downloading any (legitimate or pirated) gam
 ### Direct Download Sites:
 Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, Zippyshare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
-- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For cracked iOS apps and games.
-- [AppKed](https://www.macbed.com/games)
-- [CrackHub](https://crackhub.site) - For FitGirl repacks and scene games.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene uploads.
-- [CS.RIN.RU](https://cs.rin.ru/forum)
-- [DOS Games Archive](https://www.dosgamesarchive.com)
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
+- [AppKed](https://www.macbed.com/games) - For macOS apps and games.
+- [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
+- [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
+- [CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
+- [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
 - [G4U](https://g4u.to)
 - [Game-2U](https://game-2u.com) - For PlayStation 4 games (use the [FastForward](https://fastforward.team/install) browser extension to bypass ad shortlinks).
 - [GameDrive](https://gamedrive.org)
 - [GamesDrive](https://gamesdrive.net)
-- [GLOAD](https://gload.to)
-- [GOG Games](https://gog-games.com)
-- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames)
+- [GLOAD](https://gload.to) - For scene releases.
+- [GOG Games](https://gog-games.com) - For GOG games.
+- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
 - [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
@@ -43,20 +43,20 @@ Direct downloads are any normal download: You download the file from a server th
 - [Ova Games](https://www.ovagames.com)
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
-- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive (locked behind a password only available for members of their Discord server for at least one day) and torrent links.
+- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Requires becoming a member of their Discord server for at least 1 day to unlock Google Drive links.
 - [SKlauncher](https://skmedix.pl) - For Minecraft.
 - [SteamRIP](https://steamrip.com)
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
-- [Torrminatorr Forum](https://forum.torrminatorr.com)
-- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs.
+- [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Needs registration to access the content. Offline at the moment.
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Needs registration to access the content.
 
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
 - [1337x](https://1337x.to/cat/Games/1) - Do not download torrents uploaded by IGG Games.
-- [Mac Torrents](https://www.torrentmac.net/category/games)
-- [Mac Torrent](https://www.mactorrents.is/macos-games)
-- [NMac](https://nmac.to/category/games)
+- [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
+- [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
+- [NMac](https://nmac.to/category/games) - For macOS apps and games.
 - [RARBG](https://rarbgproxied.org/torrents.php?category=2;27;28;29;30;31;53)
 - [Rutor](http://rutor.info/games)
 - [RuTracker](https://rutracker.org/forum/index.php?c=19)
@@ -70,13 +70,13 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [CPG Repacks](https://cpgrepacks.site)
 - [DODI Repacks](https://dodi-repacks.site)
 - [Darck Repacks](https://darckrepacks.com)
-- [ElAmigos](https://elamigos.site)
+- [ElAmigos](https://elamigos.site) - Slow downloads for free users, download via GLOAD or Ova Games instead.
 - [FitGirl Repacks](https://fitgirl-repacks.site)
 - [FluxyRepacks](https://www.fluxycrack.fr)
-- [Gnarly Repacks](https://gnarly-repacks.site)
+- [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
 - [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [KAPITALSIN](https://kapitalsin.com/forum)
-- [Leechinghell](http://www.leechinghell.pw)
+- [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
 - [MagiPack Games](https://www.magipack.games)
 - Masquerade Repacks (moved to KaOsKrew)
@@ -100,9 +100,9 @@ Note: These are not for online games. Do not use cheats in online games!
 - [WeMod](https://www.wemod.com)
 
 ### Release Networks:
-Note: None of these sites provide downloads, only information on P2P and/or scene releases. Looking to see if a game is cracked? Check here!
+Note: None of these sites provide downloads, only information on P2P and/or scene releases. Wanting to see if a game is cracked? Check here!
 
-- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer "When will X game be cracked?" question.
+- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer the "When will X game be cracked?" question.
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [m2v.ru](https://m2v.ru)
 - [PreDB.de](https://predb.de/section/GAMES)
@@ -119,7 +119,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
-- [NXBrew](https://nxbrew.com)
+- [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
 - [RomUlation](https://www.romulation.net)
 - [r/Roms](https://www.reddit.com/r/roms)
 - [r/Roms Megathread](https://r-roms.github.io)
@@ -133,7 +133,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 - [Free Download Manager](https://www.freedownloadmanager.org)
 - [Internet Download Manager](https://internetdownloadmanager.com)
-- [JDownloader2](https://jdownloader.org/jdownloader2)
+- [JDownloader2](https://jdownloader.org/jdownloader2) - Automatically detects links from most sites.
 - [Motrix](https://motrix.app)
 - [pyLoad](https://pyload.net)
 - [Xtreme Download Manager](https://xtremedownloadmanager.com)
@@ -151,17 +151,17 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Tools:
 
-- [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically set your game up for CreamAPI.
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatically create Steamworks fixes.
-- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Unlock pirated DLCs on legitimate Steam games.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
-- [Lucky Patcher](https://www.luckypatchers.com) - Patch Android apps (better with root).
-- [LumaPlay (for Uplay)](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197)
-- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551)
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412)
-- [RIN SteamInternals - A Broad Collection of Steam Tools](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887)
-- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Updater tool for pirated The Sims 4 version.
-- [Steamless](https://github.com/atom0s/Steamless)
+- [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically sets your game up for CreamAPI.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic creator of Steamworks fixes.
+- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - DLC unlocker for legitimate Steam games.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - DLC unlocker for EA clients.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator that allows LAN multiplayer without internet connection.
+- [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay DLC unlocker and emulator.
+- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - List of Steam tools.
+- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirate The Sims 4 version updater.
+- [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover.
 
 ### Emulators:
 
@@ -171,33 +171,29 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [DeSmuME](https://desmume.org) - For Nintendo DS games.
 - [Dolphin Emulator](https://dolphin-emu.org) - For Nintendo GameCube and Wii games.
 - [DuckStation](https://www.duckstation.org) - For PlayStation 1 games.
-- [ePSXe](https://epsxe.com) - For PlayStation 1 games.
-- [Kega Fusion](https://www.carpeludum.com/kega-fusion) - For Sega Genesis/Mega Drive games.
 - [MAME](https://www.mamedev.org) - For arcade games.
 - [MelonDS](https://melonds.kuribo64.net) - For Nintendo DS games.
 - [mGBA](https://mgba.io) - For Game Boy Advance games.
 - [No$GBA](https://www.nogba.com) - For Game Boy Advance and Nintendo DS games.
-- [Project64](https://www.pj64-emu.com) - For Nintendo 64 games.
 - [PCSX2](https://pcsx2.net) - For PlayStation 2 games.
 - [PPSSPP](https://www.ppsspp.org) - For PlayStation Portable games.
 - [RCPS3](https://rpcs3.net) - For PlayStation 3 games.
-- [RetroArch](https://retroarch.com)
+- [RetroArch](https://retroarch.com) - For multiple consoles games.
+- [RMG](https://github.com/Rosalie241/RMG) - For Nintendo 64 games.
 - [Ryujinx](https://ryujinx.org) - For Nintendo Switch games.
 - [Snes9x](https://www.snes9x.com) - For Super Nintendo Entertainment System games.
 - [Xemu](https://xemu.app) - For original Xbox games.
 - [Xenia](https://xenia.jp) - For Xbox 360 games.
 - [Yuzu](https://yuzu-emu.org) - For Nintendo Switch games.
-- [ZSNES](https://zsnes.com) - For Super Nintendo Entertainment System games.
 
 ### Useful Software:
 
-- [7-Zip](https://7-zip.org)
+- [7-Zip](https://7-zip.org) - File archiver.
 - [Achievement Watcher](https://xan105.github.io/Achievement-Watcher)
 - [Bitwarden](https://bitwarden.com) - Open source password manager.
 - [Parsec](https://parsec.app) - Play local multiplayer games from anywhere.
-- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Verify checksums and generate hash info.
-- [Tor Browser](https://www.torproject.org)
-- [WinRAR](https://www.rarlab.com)
+- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Checksum verifier and hash info generator.
+- [Tor Browser](https://www.torproject.org) - The most private browser.
 
 **Use [MAS](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
 
@@ -227,13 +223,13 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - Game3rb
 - Games Releaser
 - GOG Unlocked/SteamUnlocked - Malicious link redirects, slow downloads and uploads stolen from IGG Games.
-- IGG Games/PCGamesTorrents - They doxed mercs213 (Good Old Downloads owner), exploit you for ad revenue and package their own DRM in indie games.
+- IGG Games/PCGamesTorrents - Has doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue and puts its own DRM in indie games.
 - MrPcGames
 - NexusGames - Malicious downloads.
 - nosTEAM
 - Ocean of Games - High malware risk.
 - Qoob/Seyter - Repacks contain bitcoin miners.
-- Repack-Games - Mislabel games and steal releases.
+- Repack-Games - Mislabels games and steals releases.
 - Steam-Repacks - Malicious downloads.
 - Steam Cracked
 - The Pirate Bay - Malware risk.
@@ -245,7 +241,6 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Unsafe Software:
 
-- μTorrent - Same as Bittorrent: Has ads and trackers and are unsafe.
+- μTorrent/Bittorent - Has ads and trackers and is unsafe.
 - Avast - Notorious for collecting and selling user data.
-- Bittorrent - Same as μTorrent: Has ads and trackers and is unsafe.
 - CCleaner - Owned by Avast.


### PR DESCRIPTION
- Added plenty of sites to the unsafe and safe lists based on CS.RIN.RU;
- Changed "Sega Genesis and Mega Drive" to "Sega Genesis/Mega Drive" and "PS4 to PlayStation 4" because they are the same console and no other abbreviations are being used, respectively;
- Changed one instance of browsers being called "web browser" (it was called "web browser" just once, so I removed the "web" part for it to be consistently called simply "browser");
- Fixed many spaces at the end of the lines.