### PR TITLE
Major Design Changes and More Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - Password: `cs.rin.ru`
   - Registration required.
 - [🌟 SteamRIP](https://steamrip.com)
+  - Steam games
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion)
-  - This is a onion route you can't visit normally, use the [Tor Browser](https://www.torproject.org/download) to visit.
+  - Use [Tor Browser](https://www.torproject.org/download) to visit this normally inaccessible onion site.
 - [Ova Games](https://www.ovagames.com)
   - Files password: `www.ovagames.com`
 - [ReleaseBB](https://rlsbb.ru/category/games/pc)
@@ -28,7 +29,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [Game-2U](https://game-2u.com/Category/game/pc)
 - [Seven Gamers](https://www.seven-gamers.com)
   - Google Drive and torrent
-  - Join [their Discord server](https://discord.com/invite/bzJkrxXXR2) for 1 day to unlock Google Drive links.
+  - 1+ day on [their Discord server](https://discord.com/invite/bzJkrxXXR2) unlocks Google Drive links.
 - [GameDrive](https://gamedrive.org)
 - [G4U](https://g4u.to)
   - Slow downloads for free users.
@@ -47,6 +48,9 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - Indie games
 - [Leechinghell](http://www.leechinghell.pw)
   - LAN multiplayer games
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum)
+  - HOGs
+  - Registration required.
 - [AppKed](https://www.macbed.com/games)
   - macOS games and apps
 - [Mobilism](https://forum.mobilism.me)
@@ -59,10 +63,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - Old games
 - [Old-Games.RU](https://www.old-games.ru/catalog/)
   - Old games
-  - Switch to English on the top right corner.
-- [Wendy's Forum](https://wendysforum.net/index.php?action=forum)
-  - HOGs
-  - Registration required.
+  - Switch to English on the top-right corner.
 - [Software Library: MS-DOS Games](https://archive.org/details/softwarelibrary_msdos_games?and[]=mediatype%3A%22software%22)
   - MS-DOS games
 - [PollyMC](https://github.com/fn2006/PollyMC)
@@ -169,7 +170,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - PlayStation 3, Portable, and Vita games
 - [Ziperto](https://www.ziperto.com)
   - Nintendo Switch and 3DS games
-- [NXBrew](https://nxbrew.com)
+- [nsw2u](https://nsw2u.com)
   - Nintendo Switch games
 - [r/Roms](https://www.reddit.com/r/roms)
 
@@ -292,9 +293,9 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [Tor Browser](https://www.torproject.org)
   - The most private browser.
 - [Achievement Watcher](https://xan105.github.io/Achievement-Watcher)
-  - Parser for achievement files with auto-screenshot, playtime tracking, and real-time notification.
+  - Achievement file parser with auto-screenshot, playtime tracking, and real-time notification.
 - [Parsec](https://parsec.app)
-  - Play local multiplayer games from anywhere.
+  - Low-latency game streaming software.
 - [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode)
   - Checksum verifier and hash info generator.
 
@@ -311,18 +312,21 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - Link shorteners bypasser.
 - [AdNauseam](https://adnauseam.io)
   - uBlock Origin-based ad content blocker that also obfuscates browsing data.
-- [ViolentMonkey](https://violentmonkey.github.io/)
-  - An open source userscript manager that supports a lot of browsers.
+- [FireMonkey](https://addons.mozilla.org/firefox/addon/firemonkey)
+  - Open source userscript manager for Firefox.
+- [Tampermonkey](https://www.tampermonkey.net)
+  - Proprietary userscript manager for most browsers.
+- [ViolentMonkey](https://violentmonkey.github.io)
+  - Open source userscript manager for many browsers.
 <ul>
   <li id="translator"><a href="https://github.com/FilipePS/Traduzir-paginas-web">TWP - Translate Web Pages</a>
     <ul>
-      <li>Translate your page in real time using Google or Yandex.</li>
+      <li>Real-time page translation via Google or Yandex.</li>
     </ul>
   </li>
 </ul>
-
 - [Firefox Multi-Account Containers](https://github.com/mozilla/multi-account-containers)
-  - Firefox Multi-Account Containers lets you keep parts of your online life separated into color-coded tabs that preserve your privacy. Cookies are separated by container, allowing you to use the web with multiple identities or accounts simultaneously.
+  - Color-coded tabs in this tool keep your online life separated, preserving your privacy. Cookies are containerized, allowing simultaneous use of multiple identities or accounts.
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 
 ### Download Managers
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://www.reddit.com/r/PiratedGames/comments/12axfj3/how_to_enhance_jdownloader2) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
 - [Motrix](https://motrix.app)
 - [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant](https://github.com/meowcateatrat/elephant) to download videos.
 - [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
@@ -136,7 +136,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 ### Tools
 
 - [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker. Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Steam, Epic Games Store, EA clients and Uplay DLC unlocker.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Steam, Epic Games Store, EA clients, and Uplay DLC unlocker.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator. Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) for managing it with a UI.
 - [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover. Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
 - [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
@@ -221,7 +221,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - AllTorrents
 - ApunKaGames
 - cracked-games/GETGAMEZ - Caught with malware.
-- CrackingPatching - Caught with [malware](https://reddit.com/qy6z3c).
+- CrackingPatching - Caught with [malware](https://www.reddit.com/qy6z3c).
 - Downloadly - Caught with crypto miners.
 - Free GOG PC Games - Modified DLLs with [IGG Games ads](https://www.reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
 - FreeTP
@@ -233,7 +233,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - NexusGames - Caught with malware.
 - nosTEAM
 - Ocean of Games - Constantly caught with malware.
-- Qoob/Seyter - Caught with crypto miners and [tried to switch names](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
+- Qoob/Seyter - Caught with crypto miners and [tried to switch names](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
 - Repack-Games - Mislabels games and steals releases.
 - Steam-Repacks - Caught with malware.
 - Steam Cracked
@@ -249,10 +249,10 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - Avast - Known for selling user data.
 - AVG/CCleaner - Owned by Avast.
 - BitComet/Bittorent - Adware.
-- BitLord - Adware.
-- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Owned](https://rentry.co/i8dwr) by [Kape](https://reddit.com/q3lepv).
-- FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
-- GShade - [Reboots](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) your computer when third-party update apps are used.
+- BitLord - [Adware](https://www.virustotal.com/gui/file/3ad1aed8bd704152157ac92afed1c51e60f205fbdce1365bad8eb9b3a69544d0).
+- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Owned](https://rentry.co/i8dwr) by [Kape](https://www.reddit.com/q3lepv).
+- FrostWire - [Adware](https://www.virustotal.com/gui/file/f20d66b647f15a5cd5f590b3065a1ef2bcd9dad307478437766640f16d416bbf/detection).
+- GShade - [Reboots](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) your computer when third-party update apps are used.
 - McAfee - Installs bloatware.
-- PolyMC - Owner [kicked all members](https://reddit.com/y6lt6s) from Discord server and repository.
-- TLauncher - [Shady](https://reddit.com/zmzzrt) business practices.
+- PolyMC - Owner [kicked all members](https://www.reddit.com/y6lt6s) from Discord server and repository.
+- TLauncher - [Shady](https://www.reddit.com/zmzzrt) business practices.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download) to visit.
 - [Ova Games](https://www.ovagames.com) - Files password: ``www.ovagames.com``.
 - [ReleaseBB](https://rlsbb.ru/category/games/pc) - For scene and P2P releases.
-- [GLOAD](https://gload.to) - For scene and P2P releases.
+- [GLOAD](https://gload.to/pc) - For scene and P2P releases.
 - [Game-2U](https://game-2u.com/Category/game/pc)
 - [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join [their Discord server](https://discord.com/invite/bzJkrxXXR2) for 1 day to access Google Drive links.
 - [GameDrive](https://gamedrive.org)
@@ -59,20 +59,17 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
 - [🌟 ElAmigos](https://elamigos.site) - Slow downloads for free users. Use GLOAD's or Ova Games' mirrors instead.
 - [🌟 KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- [Chovka](http://rutor.info/browse/0/8/1642915/0) - Can also be found at [Repack.info](https://repack.info).
+- [R.G. Mechanics](https://tapochek.net/viewforum.php?f=808)
+- [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site) -  For his repacks from up to May, 2022. Moved to KaOsKrew in June, 2022.
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- RG Mechanics
 - [Xatab](https://otxatabs.net)
 - [Darck Repacks](https://darckrepacks.com)
-- [Chovka](https://repack.info)
-- Masquerade Repacks (moved to KaOsKrew)
 - [Tiny Repacks](https://www.tiny-repacks.win)
 - [ZAZIX](https://1337x.to/user/ZAZIX/)
 - [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
 - [KAPITALSIN](https://kapitalsin.com/forum) - For lossy (lower quality and/or removed files) repacks. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
-- R.G. Catalyst
-- R.G. Revenants
-- Mr DJ
 - [MagiPack Games](https://www.magipack.games) - For old games.
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games.
 - [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](https://gog-games.com) - For GOG games.
+- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion/) - For GOG games. Requires the [TOR Browser](https://www.torproject.org/download/) to visit.
 - [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Install all before downloading games (legitimate or pirated) to prevent crashes 
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
+### Related Subreddits
+
+- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
+- [r/Piracy](https://www.reddit.com/r/Piracy)
+- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
+- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
+- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
+- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
+
 ### Direct Download Sites
 Direct downloads are safer and do not need a VPN. You may need a VPN to access blocked filehost sites (for example, Rapidgator in some EU countries). Check the download manager section below for help managing your downloads.
 
@@ -43,8 +53,8 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 ### Torrent Sites
 You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section below for more info. Torrents are P2P downloads from other users, without servers.
 
-- [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
 - [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
+- [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
@@ -80,9 +90,9 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 ### Trainers (Cheats)
 Not for online games. No cheating in online games!
 
+- [🌟 FLiNG Trainer](https://flingtrainer.com)
+- [🌟 GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
 - [WeMod](https://www.wemod.com)
-- [FLiNG Trainer](https://flingtrainer.com)
-- [GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
 - [MegaGames](https://megagames.com)
 - [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
 - [MrAntiFun](https://mrantifun.net)
@@ -137,21 +147,23 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 ### Tools
 
 - [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker. Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator. Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) for managing it with a UI.
+- [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover. Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Koalageddon](https://github.com/acidicoala/Koalageddon) - EA clients, Epic Games Store, Steam and Uplay DLC unlocker.
 - [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - EA clients and Epic Games Store DLC unlocker.
 - [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
 - [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator. Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) for managing it with a UI.
-- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
-- [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover. Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
 - [Online Fix](https://online-fix.me) - Allows playing pirated games online with other pirated copies. Password: ``online-fix.me``.
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirated The Sims 4 version updater.
-- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
 - [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
 
 ### Emulators
+
+> :exclamation: **See [gametechwiki's Emulation](https://emulation.gametechwiki.com/index.php/Main_Page) page for more.**
 
 - [Bsnes](https://github.com/bsnes-emu/bsnes) - For Super Nintendo Entertainment System games.
 - [Cemu](https://cemu.info) - For Nintendo Wii U games.
@@ -177,41 +189,32 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 ### Useful Software
 
 - [7-Zip](https://7-zip.org) - File archiver.
-- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Parser for achievement files with auto-screenshot, playtime tracking, and real-time notification.
 - [Bitwarden](https://bitwarden.com) - Open source password manager.
+- [Tor Browser](https://www.torproject.org) - The most private browser.
+- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Parser for achievement files with auto-screenshot, playtime tracking, and real-time notification.
 - [Parsec](https://parsec.app) - Play local multiplayer games from anywhere.
 - [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Checksum verifier and hash info generator.
-- [Tor Browser](https://www.torproject.org) - The most private browser.
 
-**Use [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
-
-**Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
+> :memo: **Use [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
+> :memo: **Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
 
 ### Useful Browser Extensions
 
 - [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' recommendations](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) is recommended.
-- [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 - [FastForward](https://fastforward.team) - Link shorteners bypasser.
+- [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
 - [Privacy Guides' VPN recommendations](https://www.privacyguides.org/vpn)
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/m736zt)
 
-**"Tor Browser ≠ VPN, no protection for torrenting!"**
-
-### Related Subreddits
-
-- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
-- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
-- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
-- [r/Piracy](https://www.reddit.com/r/Piracy)
-- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
-- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
+> :warning: **"Tor Browser ≠ VPN, no protection for torrenting!"**
 
 ### Untrusted Sites and Uploaders
 You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block most of the sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.
+
+> :warning: **SCENE GROUPS DO NOT HAVE SITES! Any site with a scene group name in the URL is fake.**
 
 - AGFY - Malicious redirect ads.
 - AimHaven - Malicious redirect ads.
@@ -239,7 +242,6 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - WIFI4Games - Caught with malware.
 - Worldofpcgames - Caught with malware.
 - xGIROx - Caught with crypto miners.
-- Any site with a scene group name in the URL - **SCENE GROUPS DO NOT HAVE SITES!**
 
 ### Unsafe Software
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ You must install all of these before downloading any (legitimate or pirated) gam
 ### Direct Download Sites:
 Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, Zippyshare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download. Use 
+- [🌟 SteamRIP](https://steamrip.com)
+- [🌟 Ova Games](https://www.ovagames.com)
 - [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
 - [AppKed](https://www.macbed.com/games) - For macOS apps and games.
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
 - [G4U](https://g4u.to) - Slow downloads for free users.
@@ -40,15 +42,13 @@ Direct downloads are any normal download: You download the file from a server th
 - [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Online Fix](https://online-fix.me) - For online multiplayer games.
-- [🌟 Ova Games](https://www.ovagames.com)
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
 - [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Requires becoming a member of their Discord server for at least 1 day to unlock Google Drive links.
-- [SKlauncher](https://skmedix.pl) - For Minecraft.
-- [🌟 SteamRIP](https://steamrip.com)
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
-- [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Needs registration to access the content. Offline at the moment.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Needs registration to access the content.
+- [SKlauncher](https://skmedix.pl) - For Minecraft.
+- [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Needs registration to access the content. Offline at the moment.
 
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
@@ -78,7 +78,7 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - R.G. Catalyst
 - R.G. Mechanics
 - R.G. Revenants
-- [Xatab](https://byxatab.com)
+- [Xatab](https://otxatabs.net)
 - ZAZIX
 - [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
 - [KAPITALSIN](https://kapitalsin.com/forum) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
@@ -116,21 +116,20 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 - [🌟 CDRomance](https://cdromance.com)
 - [🌟 Edge Emulation](https://edgeemu.net)
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
 - [r/Roms](https://www.reddit.com/r/roms)
 - [🌟 r/Roms Megathread](https://r-roms.github.io)
 - [ROMSPURE](https://romspure.cc)
-- [The Eye](https://the-eye.eu)
-- [The ROM Depot](https://theromdepot.com)
+- [The ROM Depot](https://theromdepot.com) - Needs registration to access the content.
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
-- [Ziperto](https://www.ziperto.com)
+- [Ziperto](https://www.ziperto.com) - For Nintendo 3DS and Switch games.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/r/Roms/comments/120c0du/how_to_download_emuparadise_isos_and_roms)) to download.
 
 ### Direct Downloading Software:
 
-- [Free Download Manager](https://www.freedownloadmanager.org)
-- [🌟 Internet Download Manager](https://internetdownloadmanager.com)
 - [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Automatically detects links from most sites.
+- [🌟 Internet Download Manager](https://internetdownloadmanager.com)
+- [Free Download Manager](https://www.freedownloadmanager.org)
 - [Motrix](https://motrix.app)
 - [pyLoad](https://pyload.net)
 - [Xtreme Download Manager](https://xtremedownloadmanager.com)
@@ -145,7 +144,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [PicoTorrent](https://picotorrent.org)
 - [BiglyBT](https://www.biglybt.com)
 - [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
-- [WebTorrent](https://webtorrent.io)
+- [WebTorrent](https://webtorrent.io) - Streaming torrent client.
 
 ### Tools:
 
@@ -202,8 +201,9 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Useful Browser Extensions:
 
-- [FastForward](https://fastforward.team) - Link shorteners bypasser.
 - [uBlock Origin](https://ublockorigin.com) - Ad content blocker.
+- [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
+- [FastForward](https://fastforward.team) - Link shorteners bypasser.
 
 ### VPNs:
 - [r/VPN](https://www.reddit.com/r/VPN)

--- a/README.md
+++ b/README.md
@@ -10,78 +10,134 @@ Install all before downloading games (legitimate or pirated) to avoid crashes fr
 ### Direct Download Sites
 Direct downloads are normal downloads from a server, being safer and not requiring a VPN. You may need a VPN to access blocked file hosts (for example, Rapidgator in some EU countries). Check the [download managers section](https://github.com/r-piratedgames/megathread#download-managers) for help managing your downloads.
 
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum)
+  - [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended.
+  - Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links.
+  - Password: ``cs.rin.ru``
+  - Registration required.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download) to visit.
-- [Ova Games](https://www.ovagames.com) - Files password: ``www.ovagames.com``.
-- [ReleaseBB](https://rlsbb.ru/category/games/pc) - For scene and P2P releases.
-- [GLOAD](https://gload.to/pc) - For scene and P2P releases.
+- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion)
+  - GOG games
+  - Use [Tor Browser](https://www.torproject.org/download) to visit.
+- [Ova Games](https://www.ovagames.com)
+  - Files password: ``www.ovagames.com``
+- [ReleaseBB](https://rlsbb.ru/category/games/pc)
+  - Scene and P2P releases
+- [GLOAD](https://gload.to/pc)
+  - Scene and P2P releases
 - [Game-2U](https://game-2u.com/Category/game/pc)
-- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join [their Discord server](https://discord.com/invite/bzJkrxXXR2) for 1 day to access Google Drive links.
+- [Seven Gamers](https://www.seven-gamers.com)
+  - Google Drive and torrent
+  - Join [their Discord server](https://discord.com/invite/bzJkrxXXR2) for 1 day to unlock Google Drive links.
 - [GameDrive](https://gamedrive.org)
-- [G4U](https://g4u.to) - Slow downloads for free users. Password: ``404``.
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Slow downloads. Password: ``www.downloadha.com``. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Scnlog](https://scnlog.me/games) - For scene releases.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - For scene releases.
-- [CrackHub](https://crackhub.site) - For scene and P2P releases.
-- [Gamdie](https://gamdie.com) - For indie games.
-- [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
-- [AppKed](https://www.macbed.com/games) - For macOS games and apps.
-- [Mobilism](https://forum.mobilism.me) - For Android games and apps.
-- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS games and apps.
-- [My Abandonware](https://www.myabandonware.com) - For old games.
-- [Old Games Download](https://oldgamesdownload.com) - For old games.
-- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
-- [Old-Games.RU](https://www.old-games.ru/catalog/) - For old games. Can be switched to English on the top right corner.
-- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Registration required.
-- [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
-- [PollyMC](https://github.com/fn2006/PollyMC) - For Minecraft.
-- [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Registration required. Offline currently.
+- [G4U](https://g4u.to)
+  - Slow downloads for free users.
+  - Password: ``404``
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game)
+  - Slow downloads.
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - Password: ``www.downloadha.com``
+- [Scnlog](https://scnlog.me/games)
+  - Scene releases
+- [Scene CrackHub](https://scene.crackhub.site)
+  - Scene releases
+- [CrackHub](https://crackhub.site)
+  - Scene and P2P releases
+- [Gamdie](https://gamdie.com)
+  - Indie games
+- [Leechinghell](http://www.leechinghell.pw)
+  - LAN multiplayer games
+- [AppKed](https://www.macbed.com/games)
+  - macOS games and apps
+- [Mobilism](https://forum.mobilism.me)
+  - Android games and apps
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8)
+  - iOS games and apps
+- [My Abandonware](https://www.myabandonware.com)
+  - Old games
+- [Old-Games.com](https://www.old-games.com)
+  - Old games
+- [Old-Games.RU](https://www.old-games.ru/catalog/)
+  - Old games
+  - Switch to English on the top right corner.
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum)
+  - HOGs
+  - Registration required.
+- [Software Library: MS-DOS Games](https://archive.org/details/softwarelibrary_msdos_games?and[]=mediatype%3A%22software%22)
+  - MS-DOS games
+- [PollyMC](https://github.com/fn2006/PollyMC)
+  - Minecraft
+- [Torrminatorr Forum [Offline Currently]](https://forum.torrminatorr.com)
+  - GOG, Linux games and scene releases
+  - Registration required.
 
 ### Torrent Sites
 Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](https://github.com/r-piratedgames/megathread#vpns) for more info.
 
-- [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
-- [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
-- [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Tapochek](https://tapochek.net/index.php?c=2) - Registration required. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [NMac](https://nmac.to/category/games) - For macOS apps and games.
-- [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
-- [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
+- [🌟 1337x](https://1337x.to/sub/10/0/)
+  - The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended
+  - Avoid IGG Games' torrents.
+- [🌟 RARBG](https://rarbg.to)
+  - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
+- [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19)
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+- [Rutor](http://rutor.info/games)
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+- [Rustorka](https://rustorka.com/forum/index.php?c=6)
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+- [Tapochek](https://tapochek.net/index.php?c=2)
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - Registration required.
+- [NMac](https://nmac.to/category/games)
+  - macOS games and apps
+- [Mac Torrents](https://www.torrentmac.net/category/games)
+  - macOS games and apps
+- [Mac Torrent](https://www.mactorrents.is/macos-games)
+  - macOS games and apps
 
 ### Repacks
 Repacks are compressed games for low-bandwidth users, but installing them takes time due to file decompression.
 
 - [🌟 DODI Repacks](https://dodi-repacks.site)
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
-- [🌟 ElAmigos](https://elamigos.site) - Slow downloads for free users. Use GLOAD's or Ova Games' mirrors instead.
+- [🌟 ElAmigos](https://elamigos.site)
+  - Slow downloads for free users, use GLOAD's or Ova Games' mirrors instead.
 - [🌟 KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
-- [Chovka](http://rutor.info/browse/0/8/1642915/0) - Can also be found at [Repack.info](https://repack.info).
+- [Chovka](http://rutor.info/browse/0/8/1642915/0)
+  - Also found on [Repack.info](https://repack.info).
 - [R.G. Mechanics](https://tapochek.net/viewforum.php?f=808)
-- [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site) -  For his repacks from up to May, 2022. Moved to KaOsKrew in June, 2022.
-- [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site)
+  - Repacks from up to May, 2022. Moved to KaOsKrew in June, 2022.
+- [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html)
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
 - [Xatab](https://otxatabs.net)
 - [Darck Repacks](https://darckrepacks.com)
 - [Tiny Repacks](https://www.tiny-repacks.win)
 - [ZAZIX](https://1337x.to/user/ZAZIX/)
-- [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
-- [KAPITALSIN](https://kapitalsin.com/forum) - For lossy (lower quality and/or removed files) repacks. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Gnarly Repacks](https://gnarly-repacks.site)
+  - Emulated console games
+- [KAPITALSIN](https://kapitalsin.com/forum)
+  - Lossy (lower quality and/or removed files) repacks
+  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
-- [MagiPack Games](https://www.magipack.games) - For old games.
-- [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games.
-- [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.
+- [MagiPack Games](https://www.magipack.games)
+  - Old games
+- [The Collection Chamber](https://collectionchamber.blogspot.com)
+  - Old games
+- [CPG Repacks](https://cpgrepacks.site)
+  - +18 anime games
 
 ### Trainers (Cheats)
 Not for online games. No cheating in online games!
 
 - [🌟 FLiNG Trainer](https://flingtrainer.com)
-- [🌟 GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
+- [🌟 GameCopyWorld](https://gamecopyworld.com/games)
+  - Also has crack only and NoCD fixes.
 - [WeMod](https://www.wemod.com)
 - [MegaGames](https://megagames.com)
-- [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
+- [FearLess Cheat Engine](https://fearlessrevolution.com)
+  - Cheat Engine tables
 - [MrAntiFun](https://mrantifun.net)
 
 ### Release Trackers
@@ -94,8 +150,11 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [srrDB](https://www.srrdb.com/browse/category:pc/1)
 - [PreDB.pw](https://predb.pw)
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
-- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. [r/PiratedGames](https://www.reddit.com/r/PiratedGames)' sister subreddit.
+- [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers)
+  - Repacks only
+- [r/RepackWorld](https://www.reddit.com/r/RepackWorld)
+  - Repacks only
+  - [r/PiratedGames](https://www.reddit.com/r/PiratedGames)' sister subreddit.
 
 ### ROM Sites
 
@@ -103,93 +162,155 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [The ROM Depot](https://theromdepot.com) - Registration required.
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Follow [this guide](https://www.reddit.com/120c0du) to download.
-- [NoPayStation](https://nopaystation.com) - For PlayStation 3, Portable, and Vita games.
-- [Ziperto](https://www.ziperto.com) - For Nintendo Switch and 3DS games.
-- [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
+- [The ROM Depot](https://theromdepot.com)
+  - Registration required.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php)
+  - [Download workaround guide](https://www.reddit.com/120c0du)
+- [NoPayStation](https://nopaystation.com)
+  - PlayStation 3, Portable, and Vita games.
+- [Ziperto](https://www.ziperto.com)
+  - Nintendo Switch and 3DS games
+- [NXBrew](https://nxbrew.com)
+  - Nintendo Switch games
 - [r/Roms](https://www.reddit.com/r/roms)
 
 ### Download Managers
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://www.reddit.com/12axfj3) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2)
+  - Detects links from most file hosts.
+  - [Enhancement guide](https://www.reddit.com/12axfj3)
+  - Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver).
+  - [Dark theme](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme)
 - [Motrix](https://motrix.app)
-- [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant](https://github.com/meowcateatrat/elephant) to download videos.
-- [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
+- [Free Download Manager](https://www.freedownloadmanager.org)
+  - Use [Elephant](https://github.com/meowcateatrat/elephant) to download videos.
+- [Internet Download Manager](https://internetdownloadmanager.com)
+  - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended.
+  - Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) for infinite use.
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
 
 ### Torrent Clients
 
-- [🌟 qBittorrent](https://www.qbittorrent.org) - [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) is recommended. See [this](https://draculatheme.com/qbittorrent) for a dark theme.
+- [🌟 qBittorrent](https://www.qbittorrent.org)
+  - [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) is recommended.
+  - [Dark theme](https://draculatheme.com/qbittorrent)
 - [🌟 Transmission](https://transmissionbt.com)
 - [Deluge](https://dev.deluge-torrent.org)
 - [Tixati](https://tixati.com)
 - [Motrix](https://motrix.app)
 - [PicoTorrent](https://picotorrent.org)
 - [BiglyBT](https://www.biglybt.com)
-- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
+- [LibreTorrent](https://github.com/proninyaroslav/libretorrent)
+  - Android devices
 
 ### Tools
 
-- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker. Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Steam, Epic Games Store, EA clients, and Uplay DLC unlocker.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator. Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) for managing it with a UI.
-- [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover. Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
-- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
-- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - Epic Games Store and EA clients DLC unlocker.
-- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
-- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
-- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
-- [Online Fix](https://online-fix.me) - Allows playing pirated games online with other pirated copies. Password: ``online-fix.me``.
-- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirated The Sims 4 version updater.
-- [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
+- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576)
+  - Legitimate Steam game DLC unlocker.
+  - Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon)
+  - Steam, Epic Games Store, EA clients, and Uplay DLC unlocker.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
+  - Steam emulator.
+  - Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) to manage it with a UI.
+- [Steamless](https://github.com/atom0s/Steamless)
+  - SteamStub DRM remover.
+  - Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112)
+  - Automatic Steamworks fix creator.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887)
+  - Steam tools list.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520)
+  - Epic Games Store and EA clients DLC unlocker.
+- [ScreamAPI](https://github.com/acidicoala/ScreamAPI)
+  - Epic Games Store DLC unlocker.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412)
+  - EA clients DLC unlocker.
+- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551)
+  - Epic Online Services emulator.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197)
+  - Uplay emulator.
+- [Online Fix](https://online-fix.me)
+  - Allows playing pirated games online with other pirated copies.
+  - Password: ``online-fix.me``
+- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519)
+  - Pirated The Sims 4 version updater.
+- [Lucky Patcher](https://www.luckypatchers.com)
+  - Android apps patcher (better with root).
 
 ### Emulators
 
 > :exclamation: **See the [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) for more.**
 > 
-- [RetroArch](https://retroarch.com) - For multiple consoles games.
-- [Ryujinx](https://ryujinx.org) - For Nintendo Switch games.
-- [yzu](https://yuzu-emu.org) - For Nintendo Switch games.
-- [Cemu](https://cemu.info) - For Wii U games.
-- [Citra](https://citra-emu.org) - For Nintendo 3DS games.
-- [Dolphin Emulator](https://dolphin-emu.org) - For Wii and GameCube games.
-- [RCPS3](https://rpcs3.net) - For PlayStation 3 games.
-- [xenia](https://xenia.jp) - For Xbox 360 games.
-- [MAME](https://www.mamedev.org) - For arcade games.
-- [PPSSPP](https://www.ppsspp.org) - For PlayStation Portable games.
-- [melonDS](https://melonds.kuribo64.net) - For Nintendo DS games.
-- [DeSmuME](https://desmume.org) - For Nintendo DS games.
-- [No$GBA](https://www.nogba.com) - For Nintendo DS and Game Boy Advance games.
-- [xemu](https://xemu.app) - For original Xbox games.
-- [mGBA](https://mgba.io) - For Game Boy Advance games.
-- [PCSX2](https://pcsx2.net) - For PlayStation 2 games.
-- [RMG](https://github.com/Rosalie241/RMG) - For Nintendo 64 games.
-- [DuckStation](https://www.duckstation.org) - For PlayStation 1 games.
-- [bsnes](https://github.com/bsnes-emu/bsnes) - For Super Nintendo Entertainment System games.
-- [Snes9x](https://www.snes9x.com) - For Super Nintendo Entertainment System games.
+- [RetroArch](https://retroarch.com) - Multiple consoles games
+- [Ryujinx](https://ryujinx.org)
+  - Nintendo Switch games
+- [yzu](https://yuzu-emu.org)
+  - Nintendo Switch games
+- [Cemu](https://cemu.info)
+  - Wii U games
+- [Citra](https://citra-emu.org)
+  - Nintendo 3DS games
+- [Dolphin Emulator](https://dolphin-emu.org)
+  - Wii and GameCube games
+- [RCPS3](https://rpcs3.net)
+  - PlayStation 3 games
+- [xenia](https://xenia.jp)
+  - Xbox 360 games
+- [MAME](https://www.mamedev.org)
+  - Arcade games
+- [PPSSPP](https://www.ppsspp.org)
+  - PlayStation Portable games
+- [melonDS](https://melonds.kuribo64.net)
+  - Nintendo DS games
+- [DeSmuME](https://desmume.org)
+  - Nintendo DS games
+- [No$GBA](https://www.nogba.com)
+  - Nintendo DS and Game Boy Advance games
+- [xemu](https://xemu.app)
+  - Original Xbox games
+- [mGBA](https://mgba.io)
+  - Game Boy Advance games
+- [PCSX2](https://pcsx2.net)
+  - PlayStation 2 games
+- [RMG](https://github.com/Rosalie241/RMG)
+  - Nintendo 64 games
+- [DuckStation](https://www.duckstation.org)
+  - PlayStation 1 games
+- [bsnes](https://github.com/bsnes-emu/bsnes)
+  - Super Nintendo Entertainment System games
+- [Snes9x](https://www.snes9x.com)
+  - Super Nintendo Entertainment System games
 
 ### Useful Software
 
-- [7-Zip](https://7-zip.org) - File archiver.
-- [Bitwarden](https://bitwarden.com) - Open source password manager.
-- [Tor Browser](https://www.torproject.org) - The most private browser.
-- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Parser for achievement files with auto-screenshot, playtime tracking, and real-time notification.
-- [Parsec](https://parsec.app) - Play local multiplayer games from anywhere.
-- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Checksum verifier and hash info generator.
+- [7-Zip](https://7-zip.org)
+  - File archiver.
+- [Bitwarden](https://bitwarden.com)
+  - Open source password manager.
+- [Tor Browser](https://www.torproject.org)
+  - The most private browser.
+- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher)
+  - Parser for achievement files with auto-screenshot, playtime tracking, and real-time notification.
+- [Parsec](https://parsec.app)
+  - Play local multiplayer games from anywhere.
+- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode)
+  - Checksum verifier and hash info generator.
 
-> :memo: **Use [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
+> :memo: **Activate Microsoft products (Office and Windows) with [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts).**
 
 > :memo: **Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
 
 ### Useful Browser Extensions
 
-- [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' recommendations](https://www.privacyguides.org/desktop-browsers/#ublock-origin) is recommended.
-- [FastForward](https://fastforward.team) - Link shorteners bypasser.
-- [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
+- [uBlock Origin](https://ublockorigin.com)
+  - Ad content blocker.
+  - Following [Privacy Guides' recommendations](https://www.privacyguides.org/desktop-browsers/#ublock-origin) is recommended.
+- [FastForward](https://fastforward.team)
+  - Link shorteners bypasser.
+- [AdNauseam](https://adnauseam.io)
+  - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
@@ -213,43 +334,70 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 
 > :warning: **SCENE GROUPS DO NOT HAVE SITES! Any site with a scene group name in the URL is fake.**
 
-- AGFY - Malicious redirect ads.
-- AimHaven - Malicious redirect ads.
+- AGFY
+  - Malicious redirect ads.
+- AimHaven
+  - Malicious redirect ads.
 - AllTorrents
 - ApunKaGames
 - cracked-games/GETGAMEZ - Caught with malware.
-- CrackingPatching - Caught with [malware](https://www.reddit.com/qy6z3c).
-- Downloadly - Caught with crypto miners.
-- Free GOG PC Games - Modified DLLs with [IGG Games ads](https://www.reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
+- CrackingPatching
+  - Caught with [malware](https://www.reddit.com/qy6z3c).
+- Downloadly
+  - Caught with crypto miners.
+- Free GOG PC Games
+  - Modified DLLs with [IGG Games ads](https://www.reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
 - FreeTP
 - Game3rb
 - Games Releaser
-- GOG Unlocked/SteamUnlocked - Games stolen from IGG Games and nosTEAM, malicious redirect ads, and slow downloads.
-- IGG Games/PCGamesTorrents - Doxed mercs213 (GOG Games owner), exploits you for ad revenue, and puts its own DRM in indie games.
+- GOG Unlocked/SteamUnlocked
+  - Games stolen from IGG Games and nosTEAM, malicious redirect ads, and slow downloads.
+- IGG Games/PCGamesTorrents
+  - Doxed mercs213 (GOG Games owner), exploits you for ad revenue, and puts its own DRM in indie games.
 - MrPcGames
-- NexusGames - Caught with malware.
+- NexusGames
+  - Caught with malware.
 - nosTEAM
-- Ocean of Games - Constantly caught with malware.
-- Qoob/Seyter - Caught with crypto miners and [tried to switch names](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
-- Repack-Games - Mislabels games and steals releases.
-- Steam-Repacks - Caught with malware.
+- Ocean of Games
+  - Constantly caught with malware.
+- Qoob/Seyter
+  - Caught with crypto miners and [tried to switch names](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
+- Repack-Games
+  - Mislabels games and steals releases.
+- Steam-Repacks
+  - Caught with malware.
 - Steam Cracked
-- The Pirate Bay - High malware risk due to no moderation.
+- The Pirate Bay
+  - High malware risk due to no moderation.
 - Unlocked-Games
-- WIFI4Games - Caught with malware.
-- Worldofpcgames - Caught with malware.
-- xGIROx - Caught with crypto miners.
+- WIFI4Games
+  - Caught with malware.
+- Worldofpcgames
+  - Caught with malware.
+- xGIROx
+  - Caught with crypto miners.
 
 ### Unsafe Software
 
-- μTorrent - Has ads and trackers and [is unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
-- Avast - Known for selling user data.
-- AVG/CCleaner - Owned by Avast.
-- BitComet/Bittorent - Adware.
-- BitLord - [Adware](https://www.virustotal.com/gui/file/3ad1aed8bd704152157ac92afed1c51e60f205fbdce1365bad8eb9b3a69544d0).
-- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Owned](https://rentry.co/i8dwr) by [Kape](https://www.reddit.com/q3lepv).
-- FrostWire - [Adware](https://www.virustotal.com/gui/file/f20d66b647f15a5cd5f590b3065a1ef2bcd9dad307478437766640f16d416bbf/detection).
-- GShade - [Reboots](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) your computer when third-party update apps are used.
-- McAfee - Installs bloatware.
-- PolyMC - Owner [kicked all members](https://www.reddit.com/y6lt6s) from Discord server and repository.
-- TLauncher - [Shady](https://www.reddit.com/zmzzrt) business practices.
+- μTorrent
+  - Has ads and trackers and [is unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- Avast
+  - Sells user data.
+- AVG/CCleaner
+  - Owned by Avast.
+- BitComet/Bittorent
+  - Adware
+- BitLord
+  - [Adware](https://www.virustotal.com/gui/file/3ad1aed8bd704152157ac92afed1c51e60f205fbdce1365bad8eb9b3a69544d0)
+- CyberGhost/ExpressVPN/Private Internet Access/ZenMate
+  - [Owned](https://rentry.co/i8dwr) by [Kape](https://www.reddit.com/q3lepv).
+- FrostWire
+  - [Adware](https://www.virustotal.com/gui/file/f20d66b647f15a5cd5f590b3065a1ef2bcd9dad307478437766640f16d416bbf/detection)
+- GShade
+  - [Reboots](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) your computer when third-party update apps are used.
+- McAfee
+  - Installs bloatware.
+- PolyMC
+  - Owner [kicked all members](https://www.reddit.com/y6lt6s) from Discord server and repository.
+- TLauncher
+  - [Shady](https://www.reddit.com/zmzzrt) business practices.

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download) to visit.
 - [Ova Games](https://www.ovagames.com)
-- [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [G4U](https://g4u.to) - Slow downloads for free users. Password: ``404``.
-- [Game-2U](https://game-2u.com) - For PlayStation 4 games.
-- [GameDrive](https://gamedrive.org)
-- [GLOAD](https://gload.to) - For scene releases.
+- [ReleaseBB](https://rlsbb.ru/category/games/pc) - For scene and P2P releases.
+- [GLOAD](https://gload.to) - For scene and P2P releases.
+- [Game-2U](https://game-2u.com/Category/game/pc)
 - [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join [their Discord server](https://discord.com/invite/bzJkrxXXR2) for 1 day to access Google Drive links.
-- [ReleaseBB](https://rlsbb.ru/category/games)
-- [Scnlog](https://scnlog.me/games)
+- [GameDrive](https://gamedrive.org)
+- [G4U](https://g4u.to) - Slow downloads for free users. Password: ``404``.
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Slow downloads. Password: ``www.downloadha.com``. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Scnlog](https://scnlog.me/games) - For scene releases.
+- [CrackHub [Scene Games]](https://scene.crackhub.site) - For scene releases.
+- [CrackHub](https://crackhub.site) - For scene and P2P releases.
 - [Gamdie](https://gamdie.com) - For indie games.
 - [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
 - [AppKed](https://www.macbed.com/games) - For macOS games and apps.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Checksum verifier and hash info generator.
 
 > :memo: **Use [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
+
 > :memo: **Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
 
 ### Useful Browser Extensions

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Direct downloads are any normal download: You download the file from a server th
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
-- [1337x](https://1337x.to/cat/Games/1) - Avoid torrents uploaded by IGG Games.
+- [1337x](https://1337x.to/cat/Games/1/) - Avoid torrents uploaded by IGG Games.
 - [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
 - [NMac](https://nmac.to/category/games) - For macOS apps and games.
@@ -153,12 +153,15 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically sets your game up for CreamAPI.
 - [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic creator of Steamworks fixes.
 - [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - DLC unlocker for legitimate Steam games.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - DLC unlocker for Epic Games Store and EA clients.
 - [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - DLC unlocker for EA clients.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator that allows LAN multiplayer without internet connection.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - DLC unlocker for EA clients, Epic Games Store, Steam and Uplay.
 - [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
-- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay DLC unlocker and emulator.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
 - [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - List of Steam tools.
+- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirate The Sims 4 version updater.
 - [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover.
 
@@ -208,38 +211,45 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Privacy Guides' VPN recommendations](https://www.privacyguides.org/vpn)
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/r/VPN/comments/m736zt/vpn_comparison_table)
 
-**Tor is NOT a VPN, it will not protect you when torrenting!**
+**Tor Browser is NOT a VPN, it will not protect you when torrenting!**
 
 ### Untrusted Sites and Uploaders:
 
-- AGFY - Scam links.
+- AGFY - Malicious redirect ads.
+- AimHaven - Malicious redirect ads.
 - AllTorrents
 - ApunKaGames
-- cracked-games/GETGAMEZ - Malware risk.
-- CrackingPatching - Malware risk.
-- Downloadly - Contain crypto miners.
+- cracked-games/GETGAMEZ - Caught with malware.
+- CrackingPatching - Caught with malware.
+- Downloadly - Caught with crypto miners.
 - FreeTP
 - Game3rb
 - Games Releaser
-- GOG Unlocked/SteamUnlocked - Malicious link redirects, slow downloads and uploads stolen from IGG Games.
-- IGG Games/PCGamesTorrents - Has doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue and puts its own DRM in indie games.
+- GOG Unlocked/SteamUnlocked - Malicious redirect ads, slow downloads and uploads stolen from IGG Games and nosTEAM.
+- IGG Games/PCGamesTorrents - Doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue and puts its own DRM in indie games.
 - MrPcGames
-- NexusGames - Malicious downloads.
+- NexusGames - Caught with malware.
 - nosTEAM
-- Ocean of Games - High malware risk.
-- Qoob/Seyter - Repacks contain bitcoin miners.
+- Ocean of Games - Constantly caught with malware.
+- Qoob/Seyter - Caught with bitcoin miners.
 - Repack-Games - Mislabels games and steals releases.
-- Steam-Repacks - Malicious downloads.
+- Steam-Repacks - Caught with malware.
 - Steam Cracked
-- The Pirate Bay - Malware risk.
+- The Pirate Bay - High malware risk.
 - Unlocked-Games
-- WIFI4Games - Malicious downloads.
-- Worldofpcgames - Malicious downloads.
-- xGIROx - Repacks contain bitcoin miners.
+- WIFI4Games - Caught with malware.
+- Worldofpcgames - Caught with malware.
+- xGIROx - Caught with bitcoin miners.
 - Any site with a scene group name in the URL - **SCENE GROUPS DO NOT HAVE SITES!**
 
 ### Unsafe Software:
 
 - μTorrent/Bittorent - Has ads and trackers and is unsafe.
-- Avast - Notorious for collecting and selling user data.
-- CCleaner - Owned by Avast.
+- Avast - Known for selling user data.
+- AVG/CCleaner - Owned by Avast.
+- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - Owned by Kape.
+- GShade - Has code that reboots your computer if you used a third-party app to manage updates.
+- McAfee - Installs bloatware.
+- now.gg - Steals accounts.
+- PolyMC - Owner kicked all members from Discord server and repository.
+- TLauncher - Shady business practices.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - Password: `404`
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game)
   - Slow downloads.
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
   - Password: `www.downloadha.com`
 - [Scnlog](https://scnlog.me/games)
   - Scene releases
@@ -80,13 +80,13 @@ Torrents are P2P downloads from other users, without servers. You will need a VP
 - [🌟 RARBG](https://rarbg.to)
   - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19)
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
 - [Rutor](http://rutor.info/games)
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
 - [Rustorka](https://rustorka.com/forum/index.php?c=6)
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
 - [Tapochek](https://tapochek.net/index.php?c=2)
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
   - Registration required.
 - [NMac](https://nmac.to/category/games)
   - macOS games and apps
@@ -109,7 +109,7 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 - [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site)
   - Repacks from up to May, 2022. Moved to KaOsKrew in June, 2022.
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html)
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
 - [Xatab](https://otxatabs.net)
 - [Darck Repacks](https://darckrepacks.com)
 - [Tiny Repacks](https://www.tiny-repacks.win)
@@ -118,7 +118,7 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
   - Emulated console games
 - [KAPITALSIN](https://kapitalsin.com/forum)
   - Lossy (lower quality and/or removed files) repacks
-  - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
+  - [Translator](#translator)
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
 - [MagiPack Games](https://www.magipack.games)
   - Old games
@@ -313,8 +313,14 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 - [ViolentMonkey](https://violentmonkey.github.io/)
   - An open source userscript manager that supports a lot of browsers.
-- [TWP - Translate Web Pages](https://github.com/FilipePS/Traduzir-paginas-web)
-  - Translate your page in real time using Google or Yandex.
+<ul>
+  <li id="translator"><a href="https://github.com/FilipePS/Traduzir-paginas-web">TWP - Translate Web Pages</a>
+    <ul>
+      <li>Translate your page in real time using Google or Yandex.</li>
+    </ul>
+  </li>
+</ul>
+
 - [Firefox Multi-Account Containers](https://github.com/mozilla/multi-account-containers)
   - Firefox Multi-Account Containers lets you keep parts of your online life separated into color-coded tabs that preserve your privacy. Cookies are separated by container, allowing you to use the web with multiple identities or accounts simultaneously.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion/) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download/) to visit.
+- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download) to visit.
 - [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
@@ -43,8 +43,8 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 ### Torrent Sites
 You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section below for more info. Torrents are P2P downloads from other users, without servers.
 
-- [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
 - [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
+- [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
@@ -87,19 +87,18 @@ Not for online games. No cheating in online games!
 - [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
 - [MrAntiFun](https://mrantifun.net)
 
-### Release Networks
+### Release Trackers
 No downloads provided. Sites offer P2P/scene release info. Check here to see if a game is cracked!
 
 - [🌟 xREL](https://www.xrel.to/games-release-list.html?lang=en_US)
-- [m2v.ru](https://m2v.ru)
-- [PreDB.de](https://predb.de/section/GAMES)
-- [PreDB.me](https://predb.me/?cats=games-pc)
+- [m2v.ru](https://m2v.ru/?func=part&Part=3)
 - [PreDB.org](https://predb.org/cats/GAMES)
+- [PreDB.de](https://predb.de/section/GAMES)
+- [srrDB](https://www.srrdb.com/browse/category:pc/1)
 - [PreDB.pw](https://predb.pw)
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. [r/PiratedGames](https://www.reddit.com/r/PiratedGames)' sister subreddit.
-- [srrDB](https://www.srrdb.com)
 
 ### ROM Sites
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-**Here is the /r/PiratedGames Megathread!** - [Translations](translations)
----
+## **Here is the /r/PiratedGames Megathread!** - [Translations](translations)
 
-### Needed Components:
+### Needed Components
 You must install all of these before downloading any (legitimate or pirated) games to stop crashing due to missing software on your computer:
 
 - [DirectX](https://www.microsoft.com/download/details.aspx?id=35)
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
-### Related Subreddits:
+### Related Subreddits
 
 - [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
@@ -18,39 +17,39 @@ You must install all of these before downloading any (legitimate or pirated) gam
 - [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
 - [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
-### Direct Download Sites:
+### Direct Download Sites
 Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, Zippyshare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
-- [🌟 Ova Games](https://www.ovagames.com)
-- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
-- [AppKed](https://www.macbed.com/games) - For macOS apps and games.
+- [🌟 GamesDrive](https://gamesdrive.net)
+- [🌟 GOG Games](https://gog-games.com) - For GOG games.
+- [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
-- [G4U](https://g4u.to) - Slow downloads for free users.
-- [Game-2U](https://game-2u.com) - For PlayStation 4 games (use the [FastForward](https://fastforward.team/install) browser extension to bypass ad shortlinks).
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [G4U](https://g4u.to) - Slow downloads for free users. Password: ``404``.
+- [Game-2U](https://game-2u.com) - For PlayStation 4 games.
 - [GameDrive](https://gamedrive.org)
-- [GamesDrive](https://gamesdrive.net)
 - [GLOAD](https://gload.to) - For scene releases.
-- [GOG Games](https://gog-games.com) - For GOG games.
-- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
+- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Requires becoming a member of their Discord server for at least 1 day to unlock Google Drive links.
+- [ReleaseBB](https://rlsbb.ru/category/games)
+- [Scnlog](https://scnlog.me/games)
+- [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
+- [AppKed](https://www.macbed.com/games) - For macOS apps and games.
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
+- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
 - [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
-- [Online Fix](https://online-fix.me) - For online multiplayer games.
-- [ReleaseBB](https://rlsbb.ru/category/games)
-- [Scnlog](https://scnlog.me/games)
-- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Requires becoming a member of their Discord server for at least 1 day to unlock Google Drive links.
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Needs registration to access the content.
-- [SKlauncher](https://skmedix.pl) - For Minecraft.
+- [PollyMC](https://github.com/fn2006/PollyMC) - For Minecraft.
 - [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Needs registration to access the content. Offline at the moment.
 
-### Torrent Sites:
+### Torrent Sites
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
 - [🌟 1337x](https://1337x.to/cat/Games/1/) - Avoid torrents uploaded by IGG Games.
@@ -63,7 +62,7 @@ You will likely need a VPN to download torrents to avoid receiving copyright not
 - [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
 
-### Repacks:
+### Repacks
 Repacks are highly compressed games, designed for people with limited and/or slow internet bandwidth. You must install them on your computer once you download them, which can take a long time due to file decompression.
 
 - [🌟 DODI Repacks](https://dodi-repacks.site)
@@ -73,21 +72,20 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [ElAmigos](https://elamigos.site) - Slow downloads for free users, download via GLOAD or Ova Games instead.
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- [Xatab](https://otxatabs.net)
 - Masquerade Repacks (moved to KaOsKrew)
 - Mr DJ
 - R.G. Catalyst
 - R.G. Mechanics
 - R.G. Revenants
-- [Xatab](https://otxatabs.net)
 - ZAZIX
 - [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
 - [KAPITALSIN](https://kapitalsin.com/forum) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
 - [Tiny Repacks](https://www.tiny-repacks.win) - For indie games.
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
 - [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.
 
-### Trainers (Cheats):
+### Trainers (Cheats)
 Note: These are not for online games. Do not cheat in online games!
 
 - [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
@@ -97,7 +95,7 @@ Note: These are not for online games. Do not cheat in online games!
 - [MrAntiFun](https://mrantifun.net)
 - [WeMod](https://www.wemod.com)
 
-### Release Networks:
+### Release Networks
 Note: None of these sites provide downloads, only information on P2P and/or scene releases. Wanting to see if a game is cracked? Check here!
 
 - [🌟 xREL](https://www.xrel.to/games-release-list.html)
@@ -112,29 +110,29 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 - [srrDB](https://www.srrdb.com)
 
-### ROM Sites:
+### ROM Sites
 
 - [🌟 r/Roms Megathread](https://r-roms.github.io)
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
-- [🌟 Edge Emulation](https://edgeemu.net)
-- [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
+- [Edge Emulation](https://edgeemu.net)
 - [r/Roms](https://www.reddit.com/r/roms)
 - [ROMSPURE](https://romspure.cc)
 - [The ROM Depot](https://theromdepot.com) - Needs registration to access the content.
 - [Ziperto](https://www.ziperto.com) - For Nintendo 3DS and Switch games.
+- [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/r/Roms/comments/120c0du/how_to_download_emuparadise_isos_and_roms) to download.
 
-### Direct Downloading Software:
+### Direct Downloading Software
 
 - [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Automatically detects links from most sites.
-- [🌟 Internet Download Manager](https://internetdownloadmanager.com)
-- [Free Download Manager](https://www.freedownloadmanager.org)
 - [Motrix](https://motrix.app)
-- [pyLoad](https://pyload.net)
+- [Free Download Manager](https://www.freedownloadmanager.org)
+- [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
+- [pyLoad](https://pyload.net)
 
-### Torrent Software:
+### Torrent Software
 
 - [🌟 qBittorrent](https://www.qbittorrent.org)
 - [🌟 Transmission](https://transmissionbt.com)
@@ -145,24 +143,24 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [BiglyBT](https://www.biglybt.com)
 - [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
 
-### Tools:
+### Tools
 
-- [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically sets your game up for CreamAPI.
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic creator of Steamworks fixes.
-- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
+- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker. Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
 - [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - EA clients and Epic Games Store DLC unlocker.
 - [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator.
 - [Koalageddon](https://github.com/acidicoala/Koalageddon) - EA clients, Epic Games Store, Steam and Uplay DLC unlocker.
-- [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
 - [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
-- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - List of Steam tools.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
 - [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
-- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirate The Sims 4 version updater.
 - [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover.
+- [Online Fix](https://online-fix.me) - For online multiplayer games.
+- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirated The Sims 4 version updater.
+- [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
 
-### Emulators:
+### Emulators
 
 - [Bsnes](https://github.com/bsnes-emu/bsnes) - For Super Nintendo Entertainment System games.
 - [Cemu](https://cemu.info) - For Nintendo Wii U games.
@@ -185,7 +183,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Xenia](https://xenia.jp) - For Xbox 360 games.
 - [Yuzu](https://yuzu-emu.org) - For Nintendo Switch games.
 
-### Useful Software:
+### Useful Software
 
 - [7-Zip](https://7-zip.org) - File archiver.
 - [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Achievement file parser that provides automatic screenshot, playtime tracking and real-time notification.
@@ -198,20 +196,20 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 **Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
 
-### Useful Browser Extensions:
+### Useful Browser Extensions
 
 - [uBlock Origin](https://ublockorigin.com) - Ad content blocker.
 - [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 - [FastForward](https://fastforward.team) - Link shorteners bypasser.
 
-### VPNs:
+### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
 - [Privacy Guides' VPN recommendations](https://www.privacyguides.org/vpn)
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/r/VPN/comments/m736zt/vpn_comparison_table)
 
 **Tor Browser is NOT a VPN, it will not protect you when torrenting!**
 
-### Untrusted Sites and Uploaders:
+### Untrusted Sites and Uploaders
 
 - AGFY - Malicious redirect ads.
 - AimHaven - Malicious redirect ads.
@@ -240,7 +238,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - xGIROx - Caught with crypto miners.
 - Any site with a scene group name in the URL - **SCENE GROUPS DO NOT HAVE SITES!**
 
-### Unsafe Software:
+### Unsafe Software
 
 - μTorrent/Bittorent - Has ads and trackers and is unsafe.
 - Avast - Known for selling user data.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - ZAZIX
 
 ### Trainers (Cheats):
-Note: These are not for online games. Do not use cheats in online games!
+Note: These are not for online games. Do not cheat in online games!
 
 - [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
 - [FLiNG Trainer](https://flingtrainer.com)
@@ -152,16 +152,16 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 - [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Automatically sets your game up for CreamAPI.
 - [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic creator of Steamworks fixes.
-- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - DLC unlocker for legitimate Steam games.
-- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - DLC unlocker for Epic Games Store and EA clients.
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - DLC unlocker for EA clients.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator that allows LAN multiplayer without internet connection.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - DLC unlocker for EA clients, Epic Games Store, Steam and Uplay.
+- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - EA clients and Epic Games Store DLC unlocker.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - EA clients, Epic Games Store, Steam and Uplay DLC unlocker.
 - [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
 - [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
 - [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - List of Steam tools.
-- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker
+- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirate The Sims 4 version updater.
 - [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover.
 
@@ -225,13 +225,13 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - FreeTP
 - Game3rb
 - Games Releaser
-- GOG Unlocked/SteamUnlocked - Malicious redirect ads, slow downloads and uploads stolen from IGG Games and nosTEAM.
+- GOG Unlocked/SteamUnlocked - Games stolen from IGG Games and nosTEAM, malicious redirect ads and slow downloads.
 - IGG Games/PCGamesTorrents - Doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue and puts its own DRM in indie games.
 - MrPcGames
 - NexusGames - Caught with malware.
 - nosTEAM
 - Ocean of Games - Constantly caught with malware.
-- Qoob/Seyter - Caught with bitcoin miners.
+- Qoob/Seyter - Caught with crypto miners.
 - Repack-Games - Mislabels games and steals releases.
 - Steam-Repacks - Caught with malware.
 - Steam Cracked
@@ -239,7 +239,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - Unlocked-Games
 - WIFI4Games - Caught with malware.
 - Worldofpcgames - Caught with malware.
-- xGIROx - Caught with bitcoin miners.
+- xGIROx - Caught with crypto miners.
 - Any site with a scene group name in the URL - **SCENE GROUPS DO NOT HAVE SITES!**
 
 ### Unsafe Software:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [My Abandonware](https://www.myabandonware.com) - For old games.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
-- [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
 - [Old-Games.RU](https://www.old-games.ru/catalog/) - For old games. Can be switched to English on the top right corner.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Registration required.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
@@ -41,7 +40,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Registration required. Offline currently.
 
 ### Torrent Sites
-Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#vpns) for more info.
+Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](https://github.com/r-piratedgames/megathread#vpns) for more info.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
 - [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
@@ -58,23 +57,24 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 
 - [🌟 DODI Repacks](https://dodi-repacks.site)
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
-- [Chovka](https://repack.info)
-- [Darck Repacks](https://darckrepacks.com)
-- [ElAmigos](https://elamigos.site) - Slow downloads for free users. Use GLOAD's or Ova Games' mirrors instead.
+- [🌟 ElAmigos](https://elamigos.site) - Slow downloads for free users. Use GLOAD's or Ova Games' mirrors instead.
+- [🌟 KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- RG Mechanics
 - [Xatab](https://otxatabs.net)
+- [Darck Repacks](https://darckrepacks.com)
+- [Chovka](https://repack.info)
 - Masquerade Repacks (moved to KaOsKrew)
-- Mr DJ
-- R.G. Catalyst
-- R.G. Mechanics
-- R.G. Revenants
-- ZAZIX
+- [Tiny Repacks](https://www.tiny-repacks.win)
+- [ZAZIX](https://1337x.to/user/ZAZIX/)
 - [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
 - [KAPITALSIN](https://kapitalsin.com/forum) - For lossy (lower quality and/or removed files) repacks. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Tiny Repacks](https://www.tiny-repacks.win) - For indie games.
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- R.G. Catalyst
+- R.G. Revenants
+- Mr DJ
 - [MagiPack Games](https://www.magipack.games) - For old games.
+- [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games.
 - [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.
 
 ### Trainers (Cheats)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [🌟 SteamRIP](https://steamrip.com)
   - Steam games
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion)
-  - Use [Tor Browser](https://www.torproject.org/download) to visit this normally inaccessible onion site.
+- [🌟 GOG Games](https://gog-games.to)
 - [Ova Games](https://www.ovagames.com)
   - Files password: `www.ovagames.com`
 - [ReleaseBB](https://rlsbb.ru/category/games/pc)

--- a/README.md
+++ b/README.md
@@ -7,16 +7,6 @@ Install all before downloading games (legitimate or pirated) to prevent crashes 
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
-### Related Subreddits
-
-- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
-- [r/Piracy](https://www.reddit.com/r/Piracy)
-- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
-- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
-- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
-- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
-
 ### Direct Download Sites
 Direct downloads are safer and do not need a VPN. You may need a VPN to access blocked filehost sites (for example, Rapidgator in some EU countries). Check the download manager section below for help managing your downloads.
 
@@ -211,6 +201,16 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/m736zt)
 
 > :warning: **"Tor Browser ≠ VPN, no protection for torrenting!"**
+
+### Related Subreddits
+
+- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
+- [r/Piracy](https://www.reddit.com/r/Piracy)
+- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
+- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
+- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
+- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
 ### Untrusted Sites and Uploaders
 You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block most of the sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.

--- a/README.md
+++ b/README.md
@@ -319,12 +319,13 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [ViolentMonkey](https://violentmonkey.github.io)
   - Open source userscript manager for many browsers.
 <ul>
-  <li id="translator"><a href="https://github.com/FilipePS/Traduzir-paginas-web">TWP - Translate Web Pages</a>
+  <li id="translator"><a href="https://github.com/FilipePS/Traduzir-paginas-web">Translate Web Pages</a>
     <ul>
       <li>Real-time page translation via Google or Yandex.</li>
     </ul>
   </li>
 </ul>
+
 - [Firefox Multi-Account Containers](https://github.com/mozilla/multi-account-containers)
   - Color-coded tabs in this tool keep your online life separated, preserving your privacy. Cookies are containerized, allowing simultaneous use of multiple identities or accounts.
 
@@ -348,7 +349,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 ### Untrusted Sites and Uploaders
 You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block most of the sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.
 
-> :warning: **SCENE GROUPS DO NOT HAVE SITES! Any site with a scene group name in the URL is fake.**
+> :warning: **SCENE GROUPS HAVE NO SITES! Sites with a scene group name in the URL are fake.**
 
 - AGFY
   - Malicious redirect ads.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## **Here is the /r/PiratedGames Megathread!** - [Translations](translations)
 
-### Needed Components
+### Required Components
 Install all before downloading games (legitimate or pirated) to prevent crashes from missing software on your computer.
 
 - [DirectX](https://www.microsoft.com/download/details.aspx?id=35)
@@ -20,7 +20,7 @@ Install all before downloading games (legitimate or pirated) to prevent crashes 
 ### Direct Download Sites
 Direct downloads are safer and do not need a VPN. You may need a VPN to access blocked filehost sites (for example, Rapidgator in some EU countries). Check the download manager section below for help managing your downloads.
 
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](https://gog-games.com) - For GOG games.
@@ -40,11 +40,11 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 - [AppKed](https://www.macbed.com/games) - For macOS apps and games.
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
 - [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
-- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
-- [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
+- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
+- [Old-Games.RU](https://www.old-games.ru/catalog/) - For old games. Can be switched to English on the bottom right corner.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Registration required.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [PollyMC](https://github.com/fn2006/PollyMC) - For Minecraft.
@@ -81,9 +81,10 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 - R.G. Revenants
 - ZAZIX
 - [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
-- [KAPITALSIN](https://kapitalsin.com/forum) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [KAPITALSIN](https://kapitalsin.com/forum) - For lossy (lower quality and/or removed files). Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Tiny Repacks](https://www.tiny-repacks.win) - For indie games.
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- [MagiPack Games](https://www.magipack.games) - For old games.
 - [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.
 
 ### Trainers (Cheats)
@@ -117,16 +118,16 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [r/Roms](https://www.reddit.com/r/roms)
 - [ROMSPURE](https://romspure.cc)
 - [The ROM Depot](https://theromdepot.com) - Registration required.
 - [Ziperto](https://www.ziperto.com) - For Nintendo 3DS and Switch games.
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/120c0du) to download.
+- [r/Roms](https://www.reddit.com/r/roms)
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Follow [this guide](https://www.reddit.com/120c0du) to download.
 
 ### Direct Downloading Software
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide]() to clean its UI up. Use [Offline Captcha Solver](https://github.com/cracker0dks/CaptchaSolver) to avoid more CAPTCHAs. See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
 - [Motrix](https://motrix.app)
 - [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant] to download videos.
 - [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
@@ -135,7 +136,7 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 
 ### Torrent Software
 
-- [🌟 qBittorrent](https://www.qbittorrent.org)
+- [🌟 qBittorrent](https://www.qbittorrent.org) - [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) is recommended. See [this](https://draculatheme.com/qbittorrent) for a dark theme.
 - [🌟 Transmission](https://transmissionbt.com)
 - [Deluge](https://dev.deluge-torrent.org)
 - [Tixati](https://tixati.com)
@@ -151,10 +152,10 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - EA clients and Epic Games Store DLC unlocker.
 - [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
 - [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator. Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) for managing it with a UI.
 - [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
-- [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover.
+- [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover. Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
 - [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
 - [Online Fix](https://online-fix.me) - Allows playing pirated games online with other pirated copies. Password: ``online-fix.me``.
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirated The Sims 4 version updater.
@@ -199,7 +200,7 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 
 ### Useful Browser Extensions
 
-- [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' suggestions](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) is recommended.
+- [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' recommendations](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) is recommended.
 - [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 - [FastForward](https://fastforward.team) - Link shorteners bypasser.
 
@@ -211,15 +212,16 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 **"Tor Browser ≠ VPN, no protection for torrenting!"**
 
 ### Untrusted Sites and Uploaders
-You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block all sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.
+You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block most of the sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.
 
 - AGFY - Malicious redirect ads.
 - AimHaven - Malicious redirect ads.
 - AllTorrents
 - ApunKaGames
-- cracked-games/GETGAMEZ - Caught with [malware](https://www.reddit.com/qy6z3c).
+- cracked-games/GETGAMEZ - Caught with malware.
 - CrackingPatching - Caught with [malware](https://reddit.com/qy6z3c).
 - Downloadly - Caught with crypto miners.
+- Free GOG PC Games - Modified DLLs with IGG Ads.
 - FreeTP
 - Game3rb
 - Games Releaser
@@ -229,7 +231,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - NexusGames - Caught with malware.
 - nosTEAM
 - Ocean of Games - Constantly caught with malware.
-- Qoob/Seyter - Caught with crypto miners and [tried to switch names afterwards](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
+- Qoob/Seyter - Caught with crypto miners and [tried to switch names](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
 - Repack-Games - Mislabels games and steals releases.
 - Steam-Repacks - Caught with malware.
 - Steam Cracked

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - Multiple consoles games
 - [Ryujinx](https://ryujinx.org)
   - Nintendo Switch games
-- [yzu](https://yuzu-emu.org)
+- [yuzu](https://yuzu-emu.org)
   - Nintendo Switch games
 - [Cemu](https://cemu.info)
   - Wii U games

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## **Here is the /r/PiratedGames Megathread!** - [Translations](translations)
+## **Here is the /r/PiratedGames Megathread!** - [Translations](./translations/)
 
 ### Required Components
 Install all before downloading games (legitimate or pirated) to avoid crashes from missing software on your computer.
@@ -13,15 +13,14 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum)
   - [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended.
   - Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links.
-  - Password: ``cs.rin.ru``
+  - Password: `cs.rin.ru`
   - Registration required.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion)
-  - GOG games
-  - Use [Tor Browser](https://www.torproject.org/download) to visit.
+  - This is a onion route you can't visit normally, use the [Tor Browser](https://www.torproject.org/download) to visit.
 - [Ova Games](https://www.ovagames.com)
-  - Files password: ``www.ovagames.com``
+  - Files password: `www.ovagames.com`
 - [ReleaseBB](https://rlsbb.ru/category/games/pc)
   - Scene and P2P releases
 - [GLOAD](https://gload.to/pc)
@@ -33,11 +32,11 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [GameDrive](https://gamedrive.org)
 - [G4U](https://g4u.to)
   - Slow downloads for free users.
-  - Password: ``404``
+  - Password: `404`
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game)
   - Slow downloads.
   - [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
-  - Password: ``www.downloadha.com``
+  - Password: `www.downloadha.com`
 - [Scnlog](https://scnlog.me/games)
   - Scene releases
 - [Scene CrackHub](https://scene.crackhub.site)
@@ -233,7 +232,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - Uplay emulator.
 - [Online Fix](https://online-fix.me)
   - Allows playing pirated games online with other pirated copies.
-  - Password: ``online-fix.me``
+  - Password: `online-fix.me`
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519)
   - Pirated The Sims 4 version updater.
 - [Lucky Patcher](https://www.luckypatchers.com)
@@ -312,6 +311,8 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - Link shorteners bypasser.
 - [AdNauseam](https://adnauseam.io)
   - uBlock Origin-based ad content blocker that also obfuscates browsing data.
+- [ViolentMonkey](https://violentmonkey.github.io/)
+  - An open source userscript manager that supports a lot of browsers
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download) to visit.
-- [Ova Games](https://www.ovagames.com)
+- [Ova Games](https://www.ovagames.com) - Files password: ``www.ovagames.com``.
 - [ReleaseBB](https://rlsbb.ru/category/games/pc) - For scene and P2P releases.
 - [GLOAD](https://gload.to) - For scene and P2P releases.
 - [Game-2U](https://game-2u.com/Category/game/pc)
@@ -47,7 +47,7 @@ Torrents are P2P downloads from other users, without servers. You will need a VP
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Tapochek](https://tapochek.net/index.php?c=2) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Tapochek](https://tapochek.net/index.php?c=2) - Registration required. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [NMac](https://nmac.to/category/games) - For macOS apps and games.
 - [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
@@ -115,7 +115,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 
 ### Download Managers
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://www.reddit.com/r/PiratedGames/comments/12axfj3/how_to_enhance_jdownloader2) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://www.reddit.com/12axfj3) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
 - [Motrix](https://motrix.app)
 - [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant](https://github.com/meowcateatrat/elephant) to download videos.
 - [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
@@ -190,7 +190,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 
 ### Useful Browser Extensions
 
-- [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' recommendations](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) is recommended.
+- [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' recommendations](https://www.privacyguides.org/desktop-browsers/#ublock-origin) is recommended.
 - [FastForward](https://fastforward.team) - Link shorteners bypasser.
 - [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion/) - For GOG games. Requires the [TOR Browser](https://www.torproject.org/download/) to visit.
+- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion/) - For GOG games. Requires the [Tor Browser](https://www.torproject.org/download/) to visit.
 - [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
@@ -153,7 +153,7 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 
 ### Emulators
 
-> :exclamation: **See [gametechwiki's Emulation](https://emulation.gametechwiki.com/index.php/Main_Page) page for more.**
+> :exclamation: **See the [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) for more.**
 
 - [Bsnes](https://github.com/bsnes-emu/bsnes) - For Super Nintendo Entertainment System games.
 - [Cemu](https://cemu.info) - For Nintendo Wii U games.
@@ -200,7 +200,7 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [Privacy Guides' VPN recommendations](https://www.privacyguides.org/vpn)
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/m736zt)
 
-> :warning: **"Tor Browser ≠ VPN, no protection for torrenting!"**
+> :warning: **Tor Browser ≠ VPN, no protection for torrenting!**
 
 ### Related Subreddits
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## **Here is the /r/PiratedGames Megathread!** - [Translations](translations)
 
 ### Required Components
-Install all before downloading games (legitimate or pirated) to prevent crashes from missing software on your computer.
+Install all before downloading games (legitimate or pirated) to avoid crashes from missing software on your computer.
 
 - [DirectX](https://www.microsoft.com/download/details.aspx?id=35)
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
@@ -22,7 +22,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 - [Game-2U](https://game-2u.com) - For PlayStation 4 games.
 - [GameDrive](https://gamedrive.org)
 - [GLOAD](https://gload.to) - For scene releases.
-- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join their Discord server for 1 day to access Google Drive links.
+- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join [their Discord server](https://discord.com/invite/bzJkrxXXR2) for 1 day to access Google Drive links.
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
 - [Gamdie](https://gamdie.com) - For indie games.
@@ -228,7 +228,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - Game3rb
 - Games Releaser
 - GOG Unlocked/SteamUnlocked - Games stolen from IGG Games and nosTEAM, malicious redirect ads, and slow downloads.
-- IGG Games/PCGamesTorrents - Doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue, and puts its own DRM in indie games.
+- IGG Games/PCGamesTorrents - Doxed mercs213 (GOG Games owner), exploits you for ad revenue, and puts its own DRM in indie games.
 - MrPcGames
 - NexusGames - Caught with malware.
 - nosTEAM

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install all before downloading games (legitimate or pirated) to prevent crashes 
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
 ### Direct Download Sites
-Direct downloads are safer and do not require a VPN. You may need a VPN to access blocked file hosts (for example, Rapidgator in some EU countries). Check the download manager section down below for help managing your downloads.
+Direct downloads are normal downloads from a server, being safer and not requiring a VPN. You may need a VPN to access blocked file hosts (for example, Rapidgator in some EU countries). Check the [download managers section](https://github.com/r-piratedgames/megathread#download-managers) for help managing your downloads.
 
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
@@ -27,9 +27,9 @@ Direct downloads are safer and do not require a VPN. You may need a VPN to acces
 - [Scnlog](https://scnlog.me/games)
 - [Gamdie](https://gamdie.com) - For indie games.
 - [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
-- [AppKed](https://www.macbed.com/games) - For macOS apps and games.
-- [Mobilism](https://forum.mobilism.me) - For Android apps and games.
-- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
+- [AppKed](https://www.macbed.com/games) - For macOS games and apps.
+- [Mobilism](https://forum.mobilism.me) - For Android games and apps.
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS games and apps.
 - [My Abandonware](https://www.myabandonware.com) - For old games.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
@@ -41,7 +41,7 @@ Direct downloads are safer and do not require a VPN. You may need a VPN to acces
 - [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Registration required. Offline currently.
 
 ### Torrent Sites
-You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section down below for more info. Torrents are P2P downloads from other users, without servers.
+Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#vpns) for more info.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
 - [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
@@ -113,7 +113,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [r/Roms](https://www.reddit.com/r/roms)
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Follow [this guide](https://www.reddit.com/120c0du) to download.
 
-### Direct Downloading Software
+### Download Managers
 
 - [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
 - [Motrix](https://motrix.app)
@@ -122,7 +122,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
 
-### Torrent Software
+### Torrent Clients
 
 - [🌟 qBittorrent](https://www.qbittorrent.org) - [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) is recommended. See [this](https://draculatheme.com/qbittorrent) for a dark theme.
 - [🌟 Transmission](https://transmissionbt.com)
@@ -136,16 +136,16 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 ### Tools
 
 - [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker. Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Steam, Epic Games Store, EA clients and Uplay DLC unlocker.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator. Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) for managing it with a UI.
 - [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover. Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
 - [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
 - [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
-- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - EA clients, Epic Games Store, Steam and Uplay DLC unlocker.
-- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - EA clients and Epic Games Store DLC unlocker.
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - Epic Games Store and EA clients DLC unlocker.
 - [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Online Fix](https://online-fix.me) - Allows playing pirated games online with other pirated copies. Password: ``online-fix.me``.
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirated The Sims 4 version updater.
 - [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
@@ -153,27 +153,27 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 ### Emulators
 
 > :exclamation: **See the [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) for more.**
-
-- [Bsnes](https://github.com/bsnes-emu/bsnes) - For Super Nintendo Entertainment System games.
+> 
+- [RetroArch](https://retroarch.com) - For multiple consoles games.
+- [Ryujinx](https://ryujinx.org) - For Nintendo Switch games.
+- [yzu](https://yuzu-emu.org) - For Nintendo Switch games.
 - [Cemu](https://cemu.info) - For Nintendo Wii U games.
 - [Citra](https://citra-emu.org) - For Nintendo 3DS games.
-- [DeSmuME](https://desmume.org) - For Nintendo DS games.
-- [Dolphin Emulator](https://dolphin-emu.org) - For Nintendo GameCube and Wii games.
-- [DuckStation](https://www.duckstation.org) - For PlayStation 1 games.
-- [MAME](https://www.mamedev.org) - For arcade games.
-- [MelonDS](https://melonds.kuribo64.net) - For Nintendo DS games.
-- [mGBA](https://mgba.io) - For Game Boy Advance games.
-- [No$GBA](https://www.nogba.com) - For Game Boy Advance and Nintendo DS games.
-- [PCSX2](https://pcsx2.net) - For PlayStation 2 games.
-- [PPSSPP](https://www.ppsspp.org) - For PlayStation Portable games.
+- [Dolphin Emulator](https://dolphin-emu.org) - For Nintendo Wii and GameCube games.
 - [RCPS3](https://rpcs3.net) - For PlayStation 3 games.
-- [RetroArch](https://retroarch.com) - For multiple consoles games.
+- [xenia](https://xenia.jp) - For Xbox 360 games.
+- [MAME](https://www.mamedev.org) - For arcade games.
+- [PPSSPP](https://www.ppsspp.org) - For PlayStation Portable games.
+- [melonDS](https://melonds.kuribo64.net) - For Nintendo DS games.
+- [DeSmuME](https://desmume.org) - For Nintendo DS games.
+- [No$GBA](https://www.nogba.com) - For Nintendo DS and Game Boy Advance games.
+- [xemu](https://xemu.app) - For original Xbox games.
+- [mGBA](https://mgba.io) - For Game Boy Advance games.
+- [PCSX2](https://pcsx2.net) - For PlayStation 2 games.
 - [RMG](https://github.com/Rosalie241/RMG) - For Nintendo 64 games.
-- [Ryujinx](https://ryujinx.org) - For Nintendo Switch games.
+- [DuckStation](https://www.duckstation.org) - For PlayStation 1 games.
+- [bsnes](https://github.com/bsnes-emu/bsnes) - For Super Nintendo Entertainment System games.
 - [Snes9x](https://www.snes9x.com) - For Super Nintendo Entertainment System games.
-- [Xemu](https://xemu.app) - For original Xbox games.
-- [Xenia](https://xenia.jp) - For Xbox 360 games.
-- [Yuzu](https://yuzu-emu.org) - For Nintendo Switch games.
 
 ### Useful Software
 
@@ -245,7 +245,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 
 ### Unsafe Software
 
-- μTorrent - Has ads and trackers and is [unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- μTorrent - Has ads and trackers and [is unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
 - Avast - Known for selling user data.
 - AVG/CCleaner - Owned by Avast.
 - BitComet/Bittorent - Adware.
@@ -254,6 +254,5 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
 - GShade - [Reboots](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) your computer when third-party update apps are used.
 - McAfee - Installs bloatware.
-- now.gg - [Steals](https://reddit.com/qu3j5q) accounts.
 - PolyMC - Owner [kicked all members](https://reddit.com/y6lt6s) from Discord server and repository.
 - TLauncher - [Shady](https://reddit.com/zmzzrt) business practices.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Direct downloads are normal downloads from a server, being safer and not requiri
 Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](https://github.com/r-piratedgames/megathread#vpns) for more info.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/)
-  - The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended
   - Avoid IGG Games' torrents.
+  - The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
 - [🌟 RARBG](https://rarbg.to)
   - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19)
@@ -167,7 +167,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php)
   - [Download workaround guide](https://www.reddit.com/120c0du)
 - [NoPayStation](https://nopaystation.com)
-  - PlayStation 3, Portable, and Vita games.
+  - PlayStation 3, Portable, and Vita games
 - [Ziperto](https://www.ziperto.com)
   - Nintendo Switch and 3DS games
 - [NXBrew](https://nxbrew.com)
@@ -243,7 +243,8 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 
 > :exclamation: **See the [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) for more.**
 > 
-- [RetroArch](https://retroarch.com) - Multiple consoles games
+- [RetroArch](https://retroarch.com)
+  - Multiple consoles games
 - [Ryujinx](https://ryujinx.org)
   - Nintendo Switch games
 - [yzu](https://yuzu-emu.org)
@@ -340,7 +341,8 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
   - Malicious redirect ads.
 - AllTorrents
 - ApunKaGames
-- cracked-games/GETGAMEZ - Caught with malware.
+- cracked-games/GETGAMEZ
+  - Caught with malware.
 - CrackingPatching
   - Caught with [malware](https://www.reddit.com/qy6z3c).
 - Downloadly

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [ROMSPURE](https://romspure.cc)
 - [The ROM Depot](https://theromdepot.com) - Registration required.
-- [Ziperto](https://www.ziperto.com) - For Nintendo 3DS and Switch games.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Follow [this guide](https://www.reddit.com/120c0du) to download.
+- [NoPayStation](https://nopaystation.com) - For PlayStation 3, Portable, and Vita games.
+- [Ziperto](https://www.ziperto.com) - For Nintendo Switch and 3DS games.
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
 - [r/Roms](https://www.reddit.com/r/roms)
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Follow [this guide](https://www.reddit.com/120c0du) to download.
 
 ### Download Managers
 
@@ -157,9 +157,9 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [RetroArch](https://retroarch.com) - For multiple consoles games.
 - [Ryujinx](https://ryujinx.org) - For Nintendo Switch games.
 - [yzu](https://yuzu-emu.org) - For Nintendo Switch games.
-- [Cemu](https://cemu.info) - For Nintendo Wii U games.
+- [Cemu](https://cemu.info) - For Wii U games.
 - [Citra](https://citra-emu.org) - For Nintendo 3DS games.
-- [Dolphin Emulator](https://dolphin-emu.org) - For Nintendo Wii and GameCube games.
+- [Dolphin Emulator](https://dolphin-emu.org) - For Wii and GameCube games.
 - [RCPS3](https://rpcs3.net) - For PlayStation 3 games.
 - [xenia](https://xenia.jp) - For Xbox 360 games.
 - [MAME](https://www.mamedev.org) - For arcade games.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You must install all of these before downloading any (legitimate or pirated) gam
 ### Direct Download Sites:
 Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, Zippyshare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
 
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download. Use 
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 Ova Games](https://www.ovagames.com)
 - [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - For iOS apps and games.
@@ -106,7 +106,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [PreDB.me](https://predb.me/?cats=games-pc)
 - [PreDB.org](https://predb.org/cats/GAMES)
 - [PreDB.pw](https://predb.pw)
-- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer the "When will X game be cracked?" question.
+- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer the “When will X game be cracked?” question.
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
   - Steam, Epic Games Store, EA clients, and Uplay DLC unlocker.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
   - Steam emulator.
-  - Use [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) to manage it with a UI.
+  - Use [GoldbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) to manage it with a UI.
 - [Steamless](https://github.com/atom0s/Steamless)
   - SteamStub DRM remover.
   - Use [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) for auto-crack with Goldberg Steam Emulator and Steamless.
@@ -312,7 +312,11 @@ No downloads provided. Sites have P2P/scene release info. Check here to see if a
 - [AdNauseam](https://adnauseam.io)
   - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 - [ViolentMonkey](https://violentmonkey.github.io/)
-  - An open source userscript manager that supports a lot of browsers
+  - An open source userscript manager that supports a lot of browsers.
+- [TWP - Translate Web Pages](https://github.com/FilipePS/Traduzir-paginas-web)
+  - Translate your page in real time using Google or Yandex.
+- [Firefox Multi-Account Containers](https://github.com/mozilla/multi-account-containers)
+  - Firefox Multi-Account Containers lets you keep parts of your online life separated into color-coded tabs that preserve your privacy. Cookies are separated by container, allowing you to use the web with multiple identities or accounts simultaneously.
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## **Here is the /r/PiratedGames Megathread!** - [Translations](translations)
 
 ### Needed Components
-You must install all of these before downloading any (legitimate or pirated) games to stop crashing due to missing software on your computer:
+Install all before downloading games (legitimate or pirated) to prevent crashes from missing software on your computer.
 
 - [DirectX](https://www.microsoft.com/download/details.aspx?id=35)
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
@@ -18,7 +18,7 @@ You must install all of these before downloading any (legitimate or pirated) gam
 - [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
 ### Direct Download Sites
-Direct downloads are any normal download: You download the file from a server through a browser. It is significantly safer to download this way and you will not need a VPN. You will need a VPN to access blocked filehost sites (for example, Zippyshare is blocked in some EU countries) in some cases. It is recommended to use a download manager mentioned further down the megathread to help managing your downloads.
+Direct downloads are safer and do not need a VPN. You may need a VPN to access blocked filehost sites (for example, Rapidgator in some EU countries). Check the download manager section below for help managing your downloads.
 
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
@@ -27,15 +27,15 @@ Direct downloads are any normal download: You download the file from a server th
 - [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
-- [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [G4U](https://g4u.to) - Slow downloads for free users. Password: ``404``.
 - [Game-2U](https://game-2u.com) - For PlayStation 4 games.
 - [GameDrive](https://gamedrive.org)
 - [GLOAD](https://gload.to) - For scene releases.
-- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Requires becoming a member of their Discord server for at least 1 day to unlock Google Drive links.
+- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join their Discord server for a day to access Google Drive links.
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
+- [Gamdie](https://gamdie.com) - For indie games.
 - [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
 - [AppKed](https://www.macbed.com/games) - For macOS apps and games.
 - [Mobilism](https://forum.mobilism.me) - For Android apps and games.
@@ -45,14 +45,15 @@ Direct downloads are any normal download: You download the file from a server th
 - [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
-- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Needs registration to access the content.
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Registration required.
+- [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [PollyMC](https://github.com/fn2006/PollyMC) - For Minecraft.
-- [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Needs registration to access the content. Offline at the moment.
+- [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Registration required. Offline currently.
 
 ### Torrent Sites
-You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
+You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section below for more info. Torrents are P2P downloads from other users, without servers.
 
-- [🌟 1337x](https://1337x.to/cat/Games/1/) - Avoid torrents uploaded by IGG Games.
+- [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games.
 - [🌟 RARBG](https://rarbg.to)
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
@@ -63,13 +64,13 @@ You will likely need a VPN to download torrents to avoid receiving copyright not
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
 
 ### Repacks
-Repacks are highly compressed games, designed for people with limited and/or slow internet bandwidth. You must install them on your computer once you download them, which can take a long time due to file decompression.
+Repacks are compressed games for low-bandwidth users, but installing them takes time due to file decompression.
 
 - [🌟 DODI Repacks](https://dodi-repacks.site)
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
 - [Chovka](https://repack.info)
 - [Darck Repacks](https://darckrepacks.com)
-- [ElAmigos](https://elamigos.site) - Slow downloads for free users, download via GLOAD or Ova Games instead.
+- [ElAmigos](https://elamigos.site) - Free users experience slow downloads. Use GLOAD's or Ova Games' mirrors instead.
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [Xatab](https://otxatabs.net)
@@ -86,17 +87,17 @@ Repacks are highly compressed games, designed for people with limited and/or slo
 - [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.
 
 ### Trainers (Cheats)
-Note: These are not for online games. Do not cheat in online games!
+Not for online games. No cheating in online games!
 
-- [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
+- [WeMod](https://www.wemod.com)
 - [FLiNG Trainer](https://flingtrainer.com)
 - [GameCopyWorld](https://gamecopyworld.com/games) - Also has crack only and NoCD fixes.
 - [MegaGames](https://megagames.com)
+- [FearLess Cheat Engine](https://fearlessrevolution.com) - Has Cheat Engine tables.
 - [MrAntiFun](https://mrantifun.net)
-- [WeMod](https://www.wemod.com)
 
 ### Release Networks
-Note: None of these sites provide downloads, only information on P2P and/or scene releases. Wanting to see if a game is cracked? Check here!
+No downloads provided. Sites offer P2P/scene release info. Check here to see if a game is cracked!
 
 - [🌟 xREL](https://www.xrel.to/games-release-list.html)
 - [m2v.ru](https://m2v.ru)
@@ -104,11 +105,11 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [PreDB.me](https://predb.me/?cats=games-pc)
 - [PreDB.org](https://predb.org/cats/GAMES)
 - [PreDB.pw](https://predb.pw)
-- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - Joke subreddit to answer the “When will X game be cracked?” question.
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
-- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
+- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. [r/PiratedGames](https://www.reddit.com/r/PiratedGames)' sister subreddit.
 - [srrDB](https://www.srrdb.com)
+- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - A subreddit for jokingly answering “When will X game be cracked?”
 
 ### ROM Sites
 
@@ -118,16 +119,16 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Edge Emulation](https://edgeemu.net)
 - [r/Roms](https://www.reddit.com/r/roms)
 - [ROMSPURE](https://romspure.cc)
-- [The ROM Depot](https://theromdepot.com) - Needs registration to access the content.
+- [The ROM Depot](https://theromdepot.com) - Registration required.
 - [Ziperto](https://www.ziperto.com) - For Nintendo 3DS and Switch games.
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/r/Roms/comments/120c0du/how_to_download_emuparadise_isos_and_roms) to download.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/120c0du) to download.
 
 ### Direct Downloading Software
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Automatically detects links from most sites.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide]() to clean its UI up. Use [Offline Captcha Solver](https://github.com/cracker0dks/CaptchaSolver) to avoid more CAPTCHAs. See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
 - [Motrix](https://motrix.app)
-- [Free Download Manager](https://www.freedownloadmanager.org)
+- [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant] to download videos.
 - [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
@@ -145,19 +146,19 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Tools
 
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
 - [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Legitimate Steam game DLC unlocker. Use [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) for automatic setup or [CreamInstaller](https://github.com/pointfeev/CreamInstaller) for automatic installation.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - EA clients, Epic Games Store, Steam and Uplay DLC unlocker.
 - [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - EA clients and Epic Games Store DLC unlocker.
 - [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - EA clients DLC unlocker.
+- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Steam emulator.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - EA clients, Epic Games Store, Steam and Uplay DLC unlocker.
 - [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Uplay emulator.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Epic Online Services emulator.
-- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
-- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Epic Games Store DLC unlocker.
 - [Steamless](https://github.com/atom0s/Steamless) - SteamStub DRM remover.
-- [Online Fix](https://online-fix.me) - For online multiplayer games.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Automatic Steamworks fix creator.
+- [Online Fix](https://online-fix.me) - Allows playing pirated games online with other pirated copies. Password: ``online-fix.me``.
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Pirated The Sims 4 version updater.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Steam tools list.
 - [Lucky Patcher](https://www.luckypatchers.com) - Android apps patcher (better with root).
 
 ### Emulators
@@ -186,52 +187,53 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 ### Useful Software
 
 - [7-Zip](https://7-zip.org) - File archiver.
-- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Achievement file parser that provides automatic screenshot, playtime tracking and real-time notification.
+- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Parser for achievement files with auto-screenshot, playtime tracking, and real-time notification.
 - [Bitwarden](https://bitwarden.com) - Open source password manager.
 - [Parsec](https://parsec.app) - Play local multiplayer games from anywhere.
 - [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Checksum verifier and hash info generator.
 - [Tor Browser](https://www.torproject.org) - The most private browser.
 
-**Use [MAS](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
+**Use [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) to activate Microsoft products (Office and Windows).**
 
 **Visit [m0nkrus](https://w14.monkrus.ws) for Adobe products.**
 
 ### Useful Browser Extensions
 
-- [uBlock Origin](https://ublockorigin.com) - Ad content blocker.
+- [uBlock Origin](https://ublockorigin.com) - Ad content blocker. Following [Privacy Guides' suggestions](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) is recommended.
 - [AdNauseam](https://adnauseam.io) - uBlock Origin-based ad content blocker that also obfuscates browsing data.
 - [FastForward](https://fastforward.team) - Link shorteners bypasser.
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
 - [Privacy Guides' VPN recommendations](https://www.privacyguides.org/vpn)
-- [VPN Comparison Table on r/VPN](https://www.reddit.com/r/VPN/comments/m736zt/vpn_comparison_table)
+- [VPN Comparison Table on r/VPN](https://www.reddit.com/m736zt)
 
-**Tor Browser is NOT a VPN, it will not protect you when torrenting!**
+**"Tor Browser ≠ VPN, no protection for torrenting!"**
 
 ### Untrusted Sites and Uploaders
+You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block all sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.
 
 - AGFY - Malicious redirect ads.
 - AimHaven - Malicious redirect ads.
 - AllTorrents
 - ApunKaGames
-- cracked-games/GETGAMEZ - Caught with malware.
-- CrackingPatching - Caught with malware.
+- cracked-games/GETGAMEZ - Caught with [malware](https://www.reddit.com/qy6z3c).
+- CrackingPatching - Caught with [malware](https://reddit.com/qy6z3c).
 - Downloadly - Caught with crypto miners.
 - FreeTP
 - Game3rb
 - Games Releaser
-- GOG Unlocked/SteamUnlocked - Games stolen from IGG Games and nosTEAM, malicious redirect ads and slow downloads.
-- IGG Games/PCGamesTorrents - Doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue and puts its own DRM in indie games.
+- GOG Unlocked/SteamUnlocked - Games stolen from IGG Games and nosTEAM, malicious redirect ads, and slow downloads.
+- IGG Games/PCGamesTorrents - Doxed mercs213 (Good Old Downloads owner), exploits you for ad revenue, and puts its own DRM in indie games.
 - MrPcGames
 - NexusGames - Caught with malware.
 - nosTEAM
 - Ocean of Games - Constantly caught with malware.
-- Qoob/Seyter - Caught with crypto miners.
+- Qoob/Seyter - Caught with crypto miners and [tried to switch names afterwards](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
 - Repack-Games - Mislabels games and steals releases.
 - Steam-Repacks - Caught with malware.
 - Steam Cracked
-- The Pirate Bay - High malware risk.
+- The Pirate Bay - High malware risk due to no moderation.
 - Unlocked-Games
 - WIFI4Games - Caught with malware.
 - Worldofpcgames - Caught with malware.
@@ -240,12 +242,15 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 
 ### Unsafe Software
 
-- μTorrent/Bittorent - Has ads and trackers and is unsafe.
+- μTorrent - Has [ads and trackers and is unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
 - Avast - Known for selling user data.
 - AVG/CCleaner - Owned by Avast.
-- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - Owned by Kape.
-- GShade - Has code that reboots your computer if you used a third-party app to manage updates.
+- BitComet/Bittorent - Adware.
+- BitLord - Adware.
+- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Owned](https://rentry.co/i8dwr) by [Kape](https://reddit.com/q3lepv).
+- FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
+- GShade - [Reboots your computer when third-party update apps are used](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt).
 - McAfee - Installs bloatware.
 - now.gg - Steals accounts.
-- PolyMC - Owner kicked all members from Discord server and repository.
-- TLauncher - Shady business practices.
+- PolyMC - Owner [kicked all members](https://reddit.com/y6lt6s) from Discord server and repository.
+- TLauncher - [Shady](https://reddit.com/zmzzrt) business practices.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install all before downloading games (legitimate or pirated) to prevent crashes 
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
 ### Direct Download Sites
-Direct downloads are safer and do not need a VPN. You may need a VPN to access blocked filehost sites (for example, Rapidgator in some EU countries). Check the download manager section below for help managing your downloads.
+Direct downloads are safer and do not require a VPN. You may need a VPN to access blocked file hosts (for example, Rapidgator in some EU countries). Check the download manager section down below for help managing your downloads.
 
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registration required. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended. Use [Baidu Bypass](https://baidu.crackhub.site) for Baidu links. Password: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
@@ -22,7 +22,7 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 - [Game-2U](https://game-2u.com) - For PlayStation 4 games.
 - [GameDrive](https://gamedrive.org)
 - [GLOAD](https://gload.to) - For scene releases.
-- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join their Discord server for a day to access Google Drive links.
+- [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Join their Discord server for 1 day to access Google Drive links.
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
 - [Gamdie](https://gamdie.com) - For indie games.
@@ -34,14 +34,14 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - For old games.
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
-- [Old-Games.RU](https://www.old-games.ru/catalog/) - For old games. Can be switched to English on the bottom right corner.
+- [Old-Games.RU](https://www.old-games.ru/catalog/) - For old games. Can be switched to English on the top right corner.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Registration required.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [PollyMC](https://github.com/fn2006/PollyMC) - For Minecraft.
 - [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Registration required. Offline currently.
 
 ### Torrent Sites
-You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section below for more info. Torrents are P2P downloads from other users, without servers.
+You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section down below for more info. Torrents are P2P downloads from other users, without servers.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
 - [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
@@ -60,7 +60,7 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
 - [Chovka](https://repack.info)
 - [Darck Repacks](https://darckrepacks.com)
-- [ElAmigos](https://elamigos.site) - Free users experience slow downloads. Use GLOAD's or Ova Games' mirrors instead.
+- [ElAmigos](https://elamigos.site) - Slow downloads for free users. Use GLOAD's or Ova Games' mirrors instead.
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [Xatab](https://otxatabs.net)
@@ -71,7 +71,7 @@ Repacks are compressed games for low-bandwidth users, but installing them takes 
 - R.G. Revenants
 - ZAZIX
 - [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
-- [KAPITALSIN](https://kapitalsin.com/forum) - For lossy (lower quality and/or removed files). Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [KAPITALSIN](https://kapitalsin.com/forum) - For lossy (lower quality and/or removed files) repacks. Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Tiny Repacks](https://www.tiny-repacks.win) - For indie games.
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
 - [MagiPack Games](https://www.magipack.games) - For old games.
@@ -88,7 +88,7 @@ Not for online games. No cheating in online games!
 - [MrAntiFun](https://mrantifun.net)
 
 ### Release Trackers
-No downloads provided. Sites offer P2P/scene release info. Check here to see if a game is cracked!
+No downloads provided. Sites have P2P/scene release info. Check here to see if a game is cracked!
 
 - [🌟 xREL](https://www.xrel.to/games-release-list.html?lang=en_US)
 - [m2v.ru](https://m2v.ru/?func=part&Part=3)
@@ -223,7 +223,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - cracked-games/GETGAMEZ - Caught with malware.
 - CrackingPatching - Caught with [malware](https://reddit.com/qy6z3c).
 - Downloadly - Caught with crypto miners.
-- Free GOG PC Games - Modified DLLs with IGG ads.
+- Free GOG PC Games - Modified DLLs with [IGG Games ads](https://www.reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
 - FreeTP
 - Game3rb
 - Games Releaser
@@ -245,15 +245,15 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 
 ### Unsafe Software
 
-- μTorrent - Has [ads and trackers and is unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- μTorrent - Has ads and trackers and is [unsafe](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
 - Avast - Known for selling user data.
 - AVG/CCleaner - Owned by Avast.
 - BitComet/Bittorent - Adware.
 - BitLord - Adware.
 - CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Owned](https://rentry.co/i8dwr) by [Kape](https://reddit.com/q3lepv).
 - FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
-- GShade - [Reboots your computer when third-party update apps are used](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt).
+- GShade - [Reboots](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) your computer when third-party update apps are used.
 - McAfee - Installs bloatware.
-- now.gg - Steals accounts.
+- now.gg - [Steals](https://reddit.com/qu3j5q) accounts.
 - PolyMC - Owner [kicked all members](https://reddit.com/y6lt6s) from Discord server and repository.
 - TLauncher - [Shady](https://reddit.com/zmzzrt) business practices.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Direct downloads are any normal download: You download the file from a server th
 - [AppKed](https://www.macbed.com/games) - For macOS apps and games.
 - [CrackHub](https://crackhub.site) - For FitGirl repacks and scene releases.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - For crackhub213's scene releases.
-- [CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Needs registration to download.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - For MS-DOS games.
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use Google Translate.
 - [G4U](https://g4u.to) - Slow downloads for free users.
@@ -40,12 +40,12 @@ Direct downloads are any normal download: You download the file from a server th
 - [Old-Games.RU](https://www.old-games.ru/catalog) - For old games. Can be switched to English on the bottom right corner.
 - [Old Games Download](https://oldgamesdownload.com) - For old games.
 - [Online Fix](https://online-fix.me) - For online multiplayer games.
-- [Ova Games](https://www.ovagames.com)
+- [🌟 Ova Games](https://www.ovagames.com)
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
 - [Seven Gamers](https://www.seven-gamers.com) - Has Google Drive and torrent links. Requires becoming a member of their Discord server for at least 1 day to unlock Google Drive links.
 - [SKlauncher](https://skmedix.pl) - For Minecraft.
-- [SteamRIP](https://steamrip.com)
+- [🌟 SteamRIP](https://steamrip.com)
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - For old games, enhanced to run on modern systems.
 - [Torrminatorr Forum](https://forum.torrminatorr.com) - For GOG and Linux games and scene releases. Needs registration to access the content. Offline at the moment.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - For HOGs. Needs registration to access the content.
@@ -53,40 +53,39 @@ Direct downloads are any normal download: You download the file from a server th
 ### Torrent Sites:
 You will likely need a VPN to download torrents to avoid receiving copyright notices from your ISP, unless your country does not care about piracy. Read more in the VPN section further in this thread. Torrents are P2P downloads: You download from other people who have downloaded the file. No servers are involved.
 
-- [1337x](https://1337x.to/cat/Games/1/) - Avoid torrents uploaded by IGG Games.
+- [🌟 1337x](https://1337x.to/cat/Games/1/) - Avoid torrents uploaded by IGG Games.
+- [🌟 RARBG](https://rarbg.to)
+- [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Tapochek](https://tapochek.net/index.php?c=2) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [NMac](https://nmac.to/category/games) - For macOS apps and games.
 - [Mac Torrents](https://www.torrentmac.net/category/games) - For macOS apps and games.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - For macOS apps and games.
-- [NMac](https://nmac.to/category/games) - For macOS apps and games.
-- [RARBG](https://rarbg.to)
-- [Rutor](http://rutor.info/games)
-- [RuTracker](https://rutracker.org/forum/index.php?c=19)
-- [Rustorka](https://rustorka.com/forum)
-- [Tapochek](https://tapochek.net)
 
 ### Repacks:
 Repacks are highly compressed games, designed for people with limited and/or slow internet bandwidth. You must install them on your computer once you download them, which can take a long time due to file decompression.
 
+- [🌟 DODI Repacks](https://dodi-repacks.site)
+- [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
 - [Chovka](https://repack.info)
-- [CPG Repacks](https://cpgrepacks.site)
 - [Darck Repacks](https://darckrepacks.com)
-- [DODI Repacks](https://dodi-repacks.site)
 - [ElAmigos](https://elamigos.site) - Slow downloads for free users, download via GLOAD or Ova Games instead.
-- [FitGirl Repacks](https://fitgirl-repacks.site)
-- [FluxyRepacks](https://www.fluxycrack.fr)
-- [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
+- [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
-- [KAPITALSIN](https://kapitalsin.com/forum)
-- [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
-- [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
 - Masquerade Repacks (moved to KaOsKrew)
 - Mr DJ
 - R.G. Catalyst
 - R.G. Mechanics
 - R.G. Revenants
-- [Scooter Repacks](https://scooter-repacks.site)
-- [Tiny Repacks](https://www.tiny-repacks.win)
 - [Xatab](https://byxatab.com)
 - ZAZIX
+- [Gnarly Repacks](https://gnarly-repacks.site) - For emulated console games.
+- [KAPITALSIN](https://kapitalsin.com/forum) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Leechinghell](http://www.leechinghell.pw) - For LAN multiplayer games.
+- [Tiny Repacks](https://www.tiny-repacks.win) - For indie games.
+- [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- [CPG Repacks](https://cpgrepacks.site) - For +18 anime games.
 
 ### Trainers (Cheats):
 Note: These are not for online games. Do not cheat in online games!
@@ -111,41 +110,41 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 - [srrDB](https://www.srrdb.com)
-- [xREL](https://www.xrel.to/games-release-list.html)
+- [🌟 xREL](https://www.xrel.to/games-release-list.html)
 
 ### ROM Sites:
 
-- [CDRomance](https://cdromance.com)
-- [Edge Emulation](https://edgeemu.net)
+- [🌟 CDRomance](https://cdromance.com)
+- [🌟 Edge Emulation](https://edgeemu.net)
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) to download.
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
 - [r/Roms](https://www.reddit.com/r/roms)
-- [r/Roms Megathread](https://r-roms.github.io)
+- [🌟 r/Roms Megathread](https://r-roms.github.io)
 - [ROMSPURE](https://romspure.cc)
-- [RomUlation](https://www.romulation.net)
 - [The Eye](https://the-eye.eu)
 - [The ROM Depot](https://theromdepot.com)
-- [Vimm's Lair](https://vimm.net/?p=vault)
+- [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [Ziperto](https://www.ziperto.com)
 
 ### Direct Downloading Software:
 
 - [Free Download Manager](https://www.freedownloadmanager.org)
-- [Internet Download Manager](https://internetdownloadmanager.com)
-- [JDownloader2](https://jdownloader.org/jdownloader2) - Automatically detects links from most sites.
+- [🌟 Internet Download Manager](https://internetdownloadmanager.com)
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Automatically detects links from most sites.
 - [Motrix](https://motrix.app)
 - [pyLoad](https://pyload.net)
 - [Xtreme Download Manager](https://xtremedownloadmanager.com)
 
 ### Torrent Software:
 
-- [BiglyBT](https://www.biglybt.com)
+- [🌟 qBittorrent](https://www.qbittorrent.org)
+- [🌟 Transmission](https://transmissionbt.com)
 - [Deluge](https://dev.deluge-torrent.org)
-- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
-- [PicoTorrent](https://picotorrent.org)
-- [qBittorrent](https://www.qbittorrent.org)
 - [Tixati](https://tixati.com)
-- [Transmission](https://transmissionbt.com)
+- [Motrix](https://motrix.app)
+- [PicoTorrent](https://picotorrent.org)
+- [BiglyBT](https://www.biglybt.com)
+- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
 - [WebTorrent](https://webtorrent.io)
 
 ### Tools:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 
 - [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detects links from most file hosts. Follow [this guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) to enhance it. Avoid more CAPTCHAs with [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). See [this](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) for a dark theme.
 - [Motrix](https://motrix.app)
-- [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant] to download videos.
+- [Free Download Manager](https://www.freedownloadmanager.org) - Use [Elephant](https://github.com/meowcateatrat/elephant) to download videos.
 - [Internet Download Manager](https://internetdownloadmanager.com) - [IDMHelper](https://github.com/unamer/IDMHelper) is recommended. Use [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) to use it forever.
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
@@ -220,7 +220,7 @@ You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent
 - cracked-games/GETGAMEZ - Caught with malware.
 - CrackingPatching - Caught with [malware](https://reddit.com/qy6z3c).
 - Downloadly - Caught with crypto miners.
-- Free GOG PC Games - Modified DLLs with IGG Ads.
+- Free GOG PC Games - Modified DLLs with IGG ads.
 - FreeTP
 - Game3rb
 - Games Releaser

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install all before downloading games (legitimate or pirated) to avoid crashes fr
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
 ### Direct Download Sites
-Direct downloads are normal downloads from a server, being safer and not requiring a VPN. You may need a VPN to access blocked file hosts (for example, Rapidgator in some EU countries). Check the [download managers section](https://github.com/r-piratedgames/megathread#download-managers) for help managing your downloads.
+Direct downloads are normal downloads from a server, being safer and not requiring a VPN. You may need a VPN to access blocked file hosts (for example, Rapidgator in some EU countries). Check the [download managers section](#download-managers) for help managing your downloads.
 
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum)
   - [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) is recommended.
@@ -72,7 +72,7 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - Registration required.
 
 ### Torrent Sites
-Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](https://github.com/r-piratedgames/megathread#vpns) for more info.
+Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](#vpns) for more info.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/)
   - Avoid IGG Games' torrents.

--- a/README.md
+++ b/README.md
@@ -7,16 +7,6 @@ Install all before downloading games (legitimate or pirated) to prevent crashes 
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
-### Related Subreddits
-
-- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
-- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
-- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
-- [r/Piracy](https://www.reddit.com/r/Piracy)
-- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
-- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
-
 ### Direct Download Sites
 Direct downloads are safer and do not need a VPN. You may need a VPN to access blocked filehost sites (for example, Rapidgator in some EU countries). Check the download manager section below for help managing your downloads.
 
@@ -53,8 +43,8 @@ Direct downloads are safer and do not need a VPN. You may need a VPN to access b
 ### Torrent Sites
 You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the VPN section below for more info. Torrents are P2P downloads from other users, without servers.
 
-- [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games.
-- [🌟 RARBG](https://rarbg.to)
+- [🌟 1337x](https://1337x.to/sub/10/0/) - Avoid torrents uploaded by IGG Games. The [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format), and [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) userscripts are recommended.
+- [🌟 RARBG](https://rarbg.to) - The [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks), and [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) userscripts are recommended.
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rutor](http://rutor.info/games) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
@@ -100,7 +90,7 @@ Not for online games. No cheating in online games!
 ### Release Networks
 No downloads provided. Sites offer P2P/scene release info. Check here to see if a game is cracked!
 
-- [🌟 xREL](https://www.xrel.to/games-release-list.html)
+- [🌟 xREL](https://www.xrel.to/games-release-list.html?lang=en_US)
 - [m2v.ru](https://m2v.ru)
 - [PreDB.de](https://predb.de/section/GAMES)
 - [PreDB.me](https://predb.me/?cats=games-pc)
@@ -110,7 +100,6 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. [r/PiratedGames](https://www.reddit.com/r/PiratedGames)' sister subreddit.
 - [srrDB](https://www.srrdb.com)
-- [r/CrackForecast](https://www.reddit.com/r/CrackForecast) - A subreddit for jokingly answering “When will X game be cracked?”
 
 ### ROM Sites
 
@@ -210,6 +199,16 @@ No downloads provided. Sites offer P2P/scene release info. Check here to see if 
 - [VPN Comparison Table on r/VPN](https://www.reddit.com/m736zt)
 
 **"Tor Browser ≠ VPN, no protection for torrenting!"**
+
+### Related Subreddits
+
+- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
+- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
+- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
+- [r/Piracy](https://www.reddit.com/r/Piracy)
+- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
+- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
 ### Untrusted Sites and Uploaders
 You can just use the [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) adblock filter to block most of the sites mentioned here and more. Follow [this guide](https://www.reddit.com/125a5xb) to add the custom filter to uBlock Origin.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Note: These are not for online games. Do not cheat in online games!
 ### Release Networks:
 Note: None of these sites provide downloads, only information on P2P and/or scene releases. Wanting to see if a game is cracked? Check here!
 
+- [🌟 xREL](https://www.xrel.to/games-release-list.html)
 - [m2v.ru](https://m2v.ru)
 - [PreDB.de](https://predb.de/section/GAMES)
 - [PreDB.me](https://predb.me/?cats=games-pc)
@@ -110,20 +111,19 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - For repacks only.
 - [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - For repacks only. Sister subreddit of [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 - [srrDB](https://www.srrdb.com)
-- [🌟 xREL](https://www.xrel.to/games-release-list.html)
 
 ### ROM Sites:
 
+- [🌟 r/Roms Megathread](https://r-roms.github.io)
+- [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
 - [🌟 Edge Emulation](https://edgeemu.net)
 - [NXBrew](https://nxbrew.com) - For Nintendo Switch games.
 - [r/Roms](https://www.reddit.com/r/roms)
-- [🌟 r/Roms Megathread](https://r-roms.github.io)
 - [ROMSPURE](https://romspure.cc)
 - [The ROM Depot](https://theromdepot.com) - Needs registration to access the content.
-- [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [Ziperto](https://www.ziperto.com) - For Nintendo 3DS and Switch games.
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/r/Roms/comments/120c0du/how_to_download_emuparadise_isos_and_roms)) to download.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Use [this userscript](https://www.reddit.com/r/Roms/comments/120c0du/how_to_download_emuparadise_isos_and_roms) to download.
 
 ### Direct Downloading Software:
 
@@ -132,7 +132,7 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [Free Download Manager](https://www.freedownloadmanager.org)
 - [Motrix](https://motrix.app)
 - [pyLoad](https://pyload.net)
-- [Xtreme Download Manager](https://xtremedownloadmanager.com)
+- [Xtreme Download Manager](https://github.com/subhra74/xdm)
 
 ### Torrent Software:
 
@@ -144,7 +144,6 @@ Note: None of these sites provide downloads, only information on P2P and/or scen
 - [PicoTorrent](https://picotorrent.org)
 - [BiglyBT](https://www.biglybt.com)
 - [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - For Android devices.
-- [WebTorrent](https://webtorrent.io) - Streaming torrent client.
 
 ### Tools:
 

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -18,8 +18,7 @@ Transferências diretas são transferências normais por um servidor, sendo mais
 - [🌟 SteamRIP](https://steamrip.com)
   - Jogos da Steam
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion)
-  - Use o [Tor Browser](https://www.torproject.org/download) para visitar este site onion normalmente inacessível.
+- [🌟 GOG Games](https://gog-games.to)
 - [Ova Games](https://www.ovagames.com)
   - Senha dos arquivos: `www.ovagames.com`
 - [ReleaseBB](https://rlsbb.ru/category/games/pc)

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -1,4 +1,4 @@
-## **Aqui Está a Megathread do /r/PiratedGames** - [Traduções](translations)
+## **Aqui Está a Megathread do /r/PiratedGames** - [Traduções](./translations/)
 
 ### Componentes Requeridos
 Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas devido a programas faltando no seu computador.
@@ -8,80 +8,136 @@ Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
 ### Sites de Transferências Diretas
-Transferências diretas são transferências normais por um servidor, sendo mais seguras e não requerindo uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
+Transferências diretas são transferências normais por um servidor, sendo mais seguras e não exigindo uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
 
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registro requerido. O [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado. Use o [Baidu Bypass](https://baidu.crackhub.site) para links do Baidu. Senha: ``cs.rin.ru``.
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum)
+  - O [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado.
+  - Use o [Baidu Bypass](https://baidu.crackhub.site) para links do Baidu.
+  - Senha: `cs.rin.ru`
+  - Registro requerido.
 - [🌟 SteamRIP](https://steamrip.com)
+  - Jogos da Steam
 - [🌟 GamesDrive](https://gamesdrive.net)
-- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - Para jogos da GOG. Requer o [Tor Browser](https://www.torproject.org/download) para visitar.
-- [Ova Games](https://www.ovagames.com) - Senha dos arquivos: ``www.ovagames.com``.
-- [ReleaseBB](https://rlsbb.ru/category/games/pc) - Para lançamentos P2P e da cena.
-- [GLOAD](https://gload.to/pc) - Para lançamentos P2P e da cena.
+- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion)
+  - Use o [Tor Browser](https://www.torproject.org/download) para visitar este site onion normalmente inacessível.
+- [Ova Games](https://www.ovagames.com)
+  - Senha dos arquivos: `www.ovagames.com`
+- [ReleaseBB](https://rlsbb.ru/category/games/pc)
+  - Lançamentos da Cena e P2P.
+- [GLOAD](https://gload.to/pc)
+  - Lançamentos da Cena e P2P.
 - [Game-2U](https://game-2u.com/Category/game/pc)
-- [Seven Gamers](https://www.seven-gamers.com) - Tem links do Google Drive e torrent. Entre no [servidor do Discord deles](https://discord.com/invite/bzJkrxXXR2) por 1 dia para acessar os links do Google Drive.
+- [Seven Gamers](https://www.seven-gamers.com)
+  - Google Drive e torrent
+  - 1+ dia no [servidor do Discord deles](https://discord.com/invite/bzJkrxXXR2) desbloqueia os links do Google Drive.
 - [GameDrive](https://gamedrive.org)
-- [G4U](https://g4u.to) - Transferências lentas para usuários grátis. Senha: ``404``.
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Transferências lentas. Senha: ``www.downloadha.com``. Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Scnlog](https://scnlog.me/games) - Para lançamentos da cena.
-- [CrackHub [Jogos da Cena]](https://scene.crackhub.site) - Para lançamentos da cena.
-- [CrackHub](https://crackhub.site) - Para lançamentos P2P e da cena.
-- [Gamdie](https://gamdie.com) - Para jogos indie.
-- [Leechinghell](http://www.leechinghell.pw) - Para jogos multijogador LAN.
-- [AppKed](https://www.macbed.com/games) - Para jogos e aplicativos de macOS.
-- [Mobilism](https://forum.mobilism.me) - Para jogos e aplicativos de Android.
-- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - Para jogos e aplicativos de iOS.
-- [My Abandonware](https://www.myabandonware.com) - Para jogos antigos.
-- [Old Games Download](https://oldgamesdownload.com) - Para jogos antigos.
-- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - Para jogos antigos.
-- [Old-Games.RU](https://www.old-games.ru/catalog/) - Para jogos antigos. Pode ser trocado para inglês no canto superior direito.
-- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - Para HOGs. Registro requerido.
-- [DOS Games Archive](https://www.dosgamesarchive.com) - Para jogos de MS-DOS.
-- [PollyMC](https://github.com/fn2006/PollyMC) - Para Minecraft.
-- [Torrminatorr Forum](https://forum.torrminatorr.com) - Para jogos da GOG e de Linux e lançamentos da cena. Registro requerido. Fora do ar atualmente.
+- [G4U](https://g4u.to)
+  - Transferências lentas para usuários grátis.
+  - Senha: `404`
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game)
+  - Transferências lentas.
+  - [Tradutor](#translator)
+  - Senha: `www.downloadha.com`
+- [Scnlog](https://scnlog.me/games)
+  - Lançamentos da Cena
+- [CrackHub](https://scene.crackhub.site)
+  - Lançamentos da Cena
+- [CrackHub](https://crackhub.site)
+  - Lançamentos da Cena e P2P
+- [Gamdie](https://gamdie.com)
+  - Jogos indie
+- [Leechinghell](http://www.leechinghell.pw)
+  - Jogos multijogador LAN
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum)
+  - HOGs
+  - Registro requerido.
+- [AppKed](https://www.macbed.com/games)
+  - Jogos e aplicativos de macOS games
+- [Mobilism](https://forum.mobilism.me)
+  - Jogos e aplicativos de Android
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8)
+  - Jogos e aplicativos de iOS
+- [My Abandonware](https://www.myabandonware.com)
+  - Jogos antigos
+- [Old-Games.com](https://www.old-games.com)
+  - Jogos antigos
+- [Old-Games.RU](https://www.old-games.ru/catalog/)
+  - Jogos antigos
+  - Mude para inglês no canto superior direito.
+- [Biblioteca de Software: Jogos de MS-DOS](https://archive.org/details/softwarelibrary_msdos_games?and[]=mediatype%3A%22software%22)
+  - Jogos de MS-DOS
+- [PollyMC](https://github.com/fn2006/PollyMC)
+  - Minecraft
+- [Torrminatorr Forum [Offline Atualmente]](https://forum.torrminatorr.com)
+  - Jogos de GOG e Linux e lançamentos da Cena
+  - Registro requerido.
 
 ### Sites de Torrents
 Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a [seção de VPNs](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#vpns) para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.
 
-- [🌟 1337x](https://1337x.to/sub/10/0/) - Evite torrents enviados pela IGG Games. Os scripts [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format) e [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) são recomendados.
-- [🌟 RARBG](https://rarbg.to) - Os scripts [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks) e [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) são recomendados.
-- [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Rutor](http://rutor.info/games) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Tapochek](https://tapochek.net/index.php?c=2) - Registro requerido Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [NMac](https://nmac.to/category/games) - Para aplicativos e jogos de macOS.
-- [Mac Torrents](https://www.torrentmac.net/category/games) - Para aplicativos e jogos de macOS.
-- [Mac Torrent](https://www.mactorrents.is/macos-games) - Para aplicativos e jogos de macOS.
+- [🌟 1337x](https://1337x.to/sub/10/0/)
+  - Evite torrents da IGG Games.
+  - Os userscripts [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format) e [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) são recomendados.
+- [🌟 RARBG](https://rarbg.to)
+  - Os userscripts [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks) e [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) são recomendados.
+- [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19)
+  - [Tradutor](#translator)
+- [Rutor](http://rutor.info/games)
+  - [Tradutor](#translator)
+- [Rustorka](https://rustorka.com/forum/index.php?c=6)
+  - [Tradutor](#translator)
+- [Tapochek](https://tapochek.net/index.php?c=2)
+  - [Tradutor](#translator)
+  - Registro requerido.
+- [NMac](https://nmac.to/category/games)
+  - Jogos e aplicativos de macOS
+- [Mac Torrents](https://www.torrentmac.net/category/games)
+  - Jogos e aplicativos de macOS
+- [Mac Torrent](https://www.mactorrents.is/macos-games)
+  - Jogos e aplicativos de macOS
 
 ### Repacks
 Repacks são jogos compactados para usuários com pouca largura de banda, mas os instalar demora mais devido à descompressão de arquivos.
 
 - [🌟 DODI Repacks](https://dodi-repacks.site)
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
-- [🌟 ElAmigos](https://elamigos.site) - Transferências lentas para usyários grátis. Use os espelhos do GLOAD ou Ova Games em vez disso.
+- [🌟 ElAmigos](https://elamigos.site)
+  - Transferências lentas para usuários grátis, use os espelhos do GLOAD ou do Ova Games em vez disso.
 - [🌟 KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
-- [Chovka](http://rutor.info/browse/0/8/1642915/0) - Também pode ser achado no [Repack.info](https://repack.info).
+- [Chovka](http://rutor.info/browse/0/8/1642915/0)
+  - Também achado no [Repack.info](https://repack.info).
 - [R.G. Mechanics](https://tapochek.net/viewforum.php?f=808)
-- [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site) -  Para seus repacks de até maio de 2022. Mudou-se para o KaOsKrew em junho de 2022.
-- [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site)
+  - Repacks de até maio de 2022. Moveu-se para o KaOsKrew em junho de 2022.
+- [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html)
+  - [Tradutor](#translator)
 - [Xatab](https://otxatabs.net)
 - [Darck Repacks](https://darckrepacks.com)
 - [Tiny Repacks](https://www.tiny-repacks.win)
 - [ZAZIX](https://1337x.to/user/ZAZIX/)
-- [Gnarly Repacks](https://gnarly-repacks.site) - Para jogos de console emulados.
-- [KAPITALSIN](https://kapitalsin.com/forum) - Para repacks com perdas (de menor qualidade e/ou com arquivos removidos). Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Gnarly Repacks](https://gnarly-repacks.site)
+  - Jogos de console emulados
+- [KAPITALSIN](https://kapitalsin.com/forum)
+  - Repacks com perdas (qualidade mais baixa e/ou arquivos removidos)
+  - [Tradutor](#translator)
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
-- [MagiPack Games](https://www.magipack.games) - Para jogos antigos.
-- [The Collection Chamber](https://collectionchamber.blogspot.com) - Para jogos antigos.
-- [CPG Repacks](https://cpgrepacks.site) - Para jogos de anime +18.
+- [MagiPack Games](https://www.magipack.games)
+  - Jogos antigos
+- [The Collection Chamber](https://collectionchamber.blogspot.com)
+  - Jogos antigos
+- [CPG Repacks](https://cpgrepacks.site)
+  - Jogos de anime +18
 
 ### Trainers (Trapaças)
 Não são para jogos online. Sem trapaças em jogos online!
 
 - [🌟 FLiNG Trainer](https://flingtrainer.com)
-- [🌟 GameCopyWorld](https://gamecopyworld.com/games) - Também tem só os cracks e correções de NoCD.
+- [🌟 GameCopyWorld](https://gamecopyworld.com/games)
+  - Também tem só o crack e correções de NoCD.
 - [WeMod](https://www.wemod.com)
 - [MegaGames](https://megagames.com)
-- [FearLess Cheat Engine](https://fearlessrevolution.com) - Tem tabelas do Cheat Engine.
+- [FearLess Cheat Engine](https://fearlessrevolution.com)
+  - Tabelas do Cheat Engine
 - [MrAntiFun](https://mrantifun.net)
 
 ### Rastreadores de Lançamentos
@@ -94,8 +150,10 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [srrDB](https://www.srrdb.com/browse/category:pc/1)
 - [PreDB.pw](https://predb.pw)
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - Só para repacks.
-- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - Só para repacks. Subreddit irmão do [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
+- [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers)
+  - Só repacks.
+- [r/RepackWorld](https://www.reddit.com/r/RepackWorld)
+  - Só repacks. Subreddit irmão do [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 
 ### Sites de ROMs
 
@@ -103,85 +161,144 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [The ROM Depot](https://theromdepot.com) - Registro requerido.
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Siga [este guia](https://www.reddit.com/120c0du) para baixar.
-- [NoPayStation](https://nopaystation.com) - Para jogos de PlayStation 3, Portable e Vita.
-- [Ziperto](https://www.ziperto.com) - Para jogos de Nintendo Switch e 3DS.
-- [NXBrew](https://nxbrew.com) - Para jogos de Nintendo Switch.
+- [The ROM Depot](https://theromdepot.com)
+  - Registro requerido.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php)
+  - Siga [este guia](https://www.reddit.com/120c0du) para baixar.
+- [NoPayStation](https://nopaystation.com)
+  - Jogos de PlayStation 3, Portable e Vita
+- [Ziperto](https://www.ziperto.com)
+  - Jogos de Nintendo Switch e 3DS
+- [nsw2u](https://nsw2u.com)
+  - Jogos de Nintendo Switch
 - [r/Roms](https://www.reddit.com/r/roms)
 
 ### Gerenciadores de Transferências
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detecta links da maioria dos hospedeiros de arquivos. Siga [este guia](https://www.reddit.com/r/PiratedGames/comments/12axfj3/how_to_enhance_jdownloader2) para o melhorar. Evite mais CAPTCHAs com o [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). Veja [isto](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) para um tema escuro.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2)
+  - Detecta links da maioria dos hospedeiros de arquivos.
+  - [Guia de melhoramento](https://www.reddit.com/12axfj3)
+  - Evite mais CAPTCHAs com o [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver).
+  - [Tema escuro](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme)
 - [Motrix](https://motrix.app)
-- [Free Download Manager](https://www.freedownloadmanager.org) - Use o [Elephant](https://github.com/meowcateatrat/elephant) para baixar vídeos.
-- [Internet Download Manager](https://internetdownloadmanager.com) -  O [IDMHelper](https://github.com/unamer/IDMHelper) é recomendado. Use o [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) para o usar para sempre.
+- [Free Download Manager](https://www.freedownloadmanager.org)
+  - Use o [Elephant](https://github.com/meowcateatrat/elephant) para baixar vídeos.
+- [Internet Download Manager](https://internetdownloadmanager.com)
+  - O [IDMHelper](https://github.com/unamer/IDMHelper) é recomendado.
+  - Use o [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) para uso infinito.
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
 
 ### Clientes de Torrents
 
-- [🌟 qBittorrent](https://www.qbittorrent.org) - O [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) é recomendado. Veja [isto](https://draculatheme.com/qbittorrent) para um tema escuro.
+- [🌟 qBittorrent](https://www.qbittorrent.org)
+  - O [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) é recomendado.
+  - [Tema escuro](https://draculatheme.com/qbittorrent)
 - [🌟 Transmission](https://transmissionbt.com)
 - [Deluge](https://dev.deluge-torrent.org)
 - [Tixati](https://tixati.com)
 - [Motrix](https://motrix.app)
 - [PicoTorrent](https://picotorrent.org)
 - [BiglyBT](https://www.biglybt.com)
-- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - Para dispositivos Android.
+- [LibreTorrent](https://github.com/proninyaroslav/libretorrent)
+  - Dispositivos de Android
 
 ### Ferramentas
 
-- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Desbloqueador de DLCs de jogos legítimos da Steam. Use o [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) para configuração automática ou o [CreamInstaller](https://github.com/pointfeev/CreamInstaller) para instalação automática.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Desbloqueador de DLCs da Steam, Epic Games Store, dos clientes da EA e da Uplay.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Emulador da Steam. Use o [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) para o gerenciar com uma IU.
-- [Steamless](https://github.com/atom0s/Steamless) - Removedor da DRM SteamStub. Use o [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) para crackear automaticamente com o Goldberg Steam Emulator e o Steamless.
-- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Criador automático de correções para o Steamworks.
-- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Lista de ferramentas da Steam.
-- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - Desbloqueador de DLCs da Epic Games Store e dos clientes da EA.
-- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Desbloqueador de DLCs da Epic Games Store.
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - Desbloqueador de DLCs dos clientes da EA.
-- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Emulador do Epic Online Services.
-- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Emulador da Uplay.
-- [Online Fix](https://online-fix.me) - Permite jogar jogos pirateados online com outras cópias pirateadas. Senha: ``online-fix.me``.
-- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Atualizador da versão pirata de The Sims 4.
-- [Lucky Patcher](https://www.luckypatchers.com) - Remendador de aplicativos de Android (melhor com root).
+- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576)
+  - Desbloqueador de DLCs de jogos legítimos da Steam.
+  - Use o [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) para configuração automática ou o [CreamInstaller](https://github.com/pointfeev/CreamInstaller) para instalação automática.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon)
+  - Desbloqueador de DLCs da Steam, Epic Games Store, dos clientes da EA e da Uplay.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
+  - Emulador da Steam.
+  - Use o [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) para o gerenciar com uma IU.
+- [Steamless](https://github.com/atom0s/Steamless)
+  - Removedor da DRM SteamStub.
+  - Use o [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) para crackear automaticamente com o Goldberg Steam Emulator e o Steamless.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112)
+  - Criador automático de correções para o Steamworks.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887)
+  - Lista de ferramentas da Steam.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520)
+  - Desbloqueador de DLCs da Epic Games Store e dos clientes da EA.
+- [ScreamAPI](https://github.com/acidicoala/ScreamAPI)
+  - Desbloqueador de DLCs da Epic Games Store.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412)
+  - Desbloqueador de DLCs dos clientes da EA.
+- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551)
+  - Emulador do Epic Online Services.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197)
+  - Emulador da Uplay.
+- [Online Fix](https://online-fix.me)
+  - Permite jogar jogos pirateados online com outras cópias pirateadas.
+  - Senha: `online-fix.me`
+- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519)
+  - Atualizador da versão pirata de The Sims 4.
+- [Lucky Patcher](https://www.luckypatchers.com)
+  - Remendador de aplicativos de Android (melhor com root).
 
 ### Emuladores
 
 > :exclamation: **Veja a [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) para nais.**
 
-- [RetroArch](https://retroarch.com) - Para jogos de vários consoles.
-- [Ryujinx](https://ryujinx.org) - Para jogos de Nintendo Switch.
-- [yuzu](https://yuzu-emu.org) - Para jogos de Nintendo Switch.
-- [Cemu](https://cemu.info) - Para jogos de Wii U.
-- [Citra](https://citra-emu.org) - Para jogos de Nintendo 3DS.
-- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos de Wii e GameCube.
-- [RCPS3](https://rpcs3.net) - Para jogos de PlayStation 3.
-- [xenia](https://xenia.jp) - Para jogos de Xbox 360.
-- [MAME](https://www.mamedev.org) - Para jogos de arcade.
-- [PPSSPP](https://www.ppsspp.org) - Para jogos de PlayStation Portable.
-- [melonDS](https://melonds.kuribo64.net) - Para jogos de Nintendo DS.
-- [DeSmuME](https://desmume.org) - Para jogos de Nintendo DS.
-- [No$GBA](https://www.nogba.com) - Para jogos de Nintendo DS e Game Boy Advance.
-- [xemu](https://xemu.app) - Para jogos de Xbox original.
-- [mGBA](https://mgba.io) - Para jogos de Game Boy Advance.
-- [PCSX2](https://pcsx2.net) - Para jogos de PlayStation 2.
-- [RMG](https://github.com/Rosalie241/RMG) - Para jogos de Nintendo 64.
-- [DuckStation](https://www.duckstation.org) - Para jogos de PlayStation 1.
-- [bsnes](https://github.com/bsnes-emu/bsnes) - Para jogos de Super Nintendo Entertainment System.
-- [Snes9x](https://www.snes9x.com) - Para jogos de Super Nintendo Entertainment System.
+- [RetroArch](https://retroarch.com)
+  - Jogos de múltiplos consoles
+- [Ryujinx](https://ryujinx.org)
+  - Jogos de Nintendo Switch
+- [yuzu](https://yuzu-emu.org)
+  - Jogos de Nintendo Switch
+- [Cemu](https://cemu.info)
+  - Jogos de Wii U
+- [Citra](https://citra-emu.org)
+  - Jogos de Nintendo 3DS
+- [Dolphin Emulator](https://dolphin-emu.org)
+  - Jogos de Wii e de GameCube
+- [RCPS3](https://rpcs3.net)
+  - Jogos de PlayStation 3
+- [xenia](https://xenia.jp)
+  - Jogos de Xbox 360
+- [MAME](https://www.mamedev.org)
+  - Jogos de Arcade
+- [PPSSPP](https://www.ppsspp.org)
+  - Jogos de PlayStation Portable
+- [melonDS](https://melonds.kuribo64.net)
+  - Jogos de Nintendo DS
+- [DeSmuME](https://desmume.org)
+  - Jogos de Nintendo DS
+- [No$GBA](https://www.nogba.com)
+  - Jogos de Nintendo DS e de Game Boy Advance
+- [xemu](https://xemu.app)
+  - Jogos de Xbox original
+- [mGBA](https://mgba.io)
+  - Jogos de Game Boy Advance
+- [PCSX2](https://pcsx2.net)
+  - Jogos de PlayStation 2
+- [RMG](https://github.com/Rosalie241/RMG)
+  - Jogos de Nintendo 64
+- [DuckStation](https://www.duckstation.org)
+  - Jogos de PlayStation 1
+- [bsnes](https://github.com/bsnes-emu/bsnes)
+  - Jogos de Super Nintendo Entertainment System
+- [Snes9x](https://www.snes9x.com)
+  - Jogos de Super Nintendo Entertainment System
 
 ### Programas Úteis
 
-- [7-Zip](https://7-zip.org) - Arquivador de arquivos.
-- [Bitwarden](https://bitwarden.com) - Gerenciador de senhas de código aberto.
-- [Tor Browser](https://www.torproject.org) - O navegador mais privado.
-- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Analisador de arquivos de conquistas com capturas de tela automáticas, rastreamento de tempo de jogo e notificações em tempo real.
-- [Parsec](https://parsec.app) - Jogue jogos multijogador local de qualquer lugar.
-- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Verificador de soma de verificação e gerador de informações de hash.
+- [7-Zip](https://7-zip.org)
+  - Arquivador de arquivos.
+- [Bitwarden](https://bitwarden.com)
+  - Gerenciador de senhas de código aberto.
+- [Tor Browser](https://www.torproject.org)
+  - O navegador mais privado.
+- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher)
+  - Analisador de arquivos de conquistas com capturas de tela automáticas, rastreamento de tempo de jogo e notificações em tempo real.
+- [Parsec](https://parsec.app)
+  - Programa de transmissão de jogos de latência baixa.
+- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode)
+  - Verificador de soma de verificação e gerador de informações de hash.
 
-> :memo: **Use o [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) para ativar produtos da Microsoft (Office e Windows).**
+> :memo: **Ative produtos da Microsoft (Office e Windows) com o [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts).**
 
 > :memo: **Visite o [m0nkrus](https://w14.monkrus.ws) para produtos da Adobe.**
 
@@ -190,6 +307,21 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [uBlock Origin](https://ublockorigin.com) - Bloqueador de conteúdo de anúncio. Seguir as [recomendações do Privacy Guides](https://www.privacyguides.org/desktop-browsers/#ublock-origin) é recomendado.
 - [FastForward](https://fastforward.team) - Contornador de encurtadores de links.
 - [AdNauseam](https://adnauseam.io) - Bloqueador de conteúdo de anúncio baseado no uBlock Origin que também ofusca os dados de navegação.
+- [FireMonkey](https://addons.mozilla.org/firefox/addon/firemonkey)
+  - Gerenciador de userscripts de código aberto para o Firefox.
+- [Tampermonkey](https://www.tampermonkey.net)
+  - Gerenciador de userscripts de código aberto para a maioria dos navegadores.
+- [ViolentMonkey](https://violentmonkey.github.io)
+  - Gerenciador de userscripts de código aberto para vários navegadores.
+<ul>
+  <li id="tradutor"><a href="https://github.com/FilipePS/Traduzir-paginas-web">Traduzir Páginas Web</a>
+    <ul>
+      <li>Tradução em tempo real via Google ou Yandex.</li>
+    </ul>
+  </li>
+</ul>
+- [Firefox Multi-Account Containers](https://github.com/mozilla/multi-account-containers)
+  - Abas com cores distintas nesta ferramenta mantém sua vida online separada, preservando sua privacidade. Os cookies são isolados em contêineres, permitindo o uso simultâneo de várias identidades ou contas.
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
@@ -211,45 +343,73 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 ### Sites e Enviadores Não Confiáveis
 Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) para bloquear a maioria dos sites mencionados aqui e mais. Siga [este guia](https://www.reddit.com/125a5xb) para adicionar o filtro customizado ao uBlock Origin.
 
-> :warning: **GRUPOS DA CENA NÃO TÊM SITES! Todo site com o nome dum grupo da cena na URL é falso.**
+> :warning: **GRUPOS DA CENA NÃO TÊM SITES! Sites com o nome dum grupo da cena na URL são falsos.**
 
-- AGFY - Anúncios de redirecionamento maliciosos.
-- AimHaven - Anúncios de redirecionamento maliciosos.
+- AGFY
+  - Anúncios de redirecionamento maliciosos.
+- AimHaven
+   - Anúncios de redirecionamento maliciosos.
 - AllTorrents
 - ApunKaGames
-- cracked-games/GETGAMEZ - Pego com malware.
-- CrackingPatching - Pego com [malware](https://reddit.com/qy6z3c).
-- Downloadly - Pego com mineradores de criptomoedas.
-- Free GOG PC Games - Modifica as DLLs com [anúncios da IGG Games](https://reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
+- cracked-games/GETGAMEZ
+  - Pego com malware.
+- CrackingPatching
+  - Pego com [malware](https://reddit.com/qy6z3c).
+- Downloadly
+  - Pego com mineradores de criptomoedas.
+- Free GOG PC Games
+  - Modifica as DLLs com [anúncios da IGG Games](https://reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
 - FreeTP
 - Game3rb
 - Games Releaser
-- GOG Unlocked/SteamUnlocked - Jogos roubados da IGG Games e nosTEAM, anúncios de redirecionamento maliciosos e transferências lentas.
-- IGG Games/PCGamesTorrents - Fez doxing com o mercs213 (dono do GOG Games), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
+- GOG Unlocked/SteamUnlocked
+  - Jogos roubados da IGG Games e nosTEAM, anúncios de redirecionamento maliciosos e transferências lentas.
+- IGG Games/PCGamesTorrents
+  - Fez doxing com o mercs213 (dono do GOG Games), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
 - MrPcGames
-- NexusGames - Pego com malware.
+- NexusGames
+  - Pego com malware.
 - nosTEAM
-- Ocean of Games - Constantemente pego com malware.
-- Qoob/Seyter - Pego com mineradores de criptomoedas e [tentou trocar de nome](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
-- Repack-Games - Rouba lançamentos e rotula os jogos errado.
-- Steam-Repacks - Pego com malware.
+- Ocean of Games
+  - Constantemente pego com malware.
+- Qoob/Seyter
+  - Pego com mineradores de criptomoedas e [tentou trocar de nome](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
+- Repack-Games
+  - Rouba lançamentos e rotula os jogos errado.
+- Steam-Repacks
+  - Pego com malware.
 - Steam Cracked
-- The Pirate Bay - Alto risco de malware devido a nenhuma moderação.
+- The Pirate Bay
+  - Risco alto de malware por falta de moderação.
 - Unlocked-Games
-- WIFI4Games - Pego com malware.
-- Worldofpcgames - Pego com malware.
-- xGIROx - Pego com mineradores de criptomoedas.
+- WIFI4Games
+  - Pego com malware.
+- Worldofpcgames
+  - Pego com malware.
+- xGIROx
+  - Pego com mineradores de criptomoedas.
 
 ### Programas Inseguros
 
-- μTorrent - Tem anúncios e rastreadores e [é inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
-- Avast - Conhecida por vender dados dos usuários.
-- AVG/CCleaner - Propriedade da Avast.
-- BitComet/Bittorent - Adware.
-- BitLord - [Adware](https://www.virustotal.com/gui/file/3ad1aed8bd704152157ac92afed1c51e60f205fbdce1365bad8eb9b3a69544d0).
-- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Propriedade](https://rentry.co/i8dwr) da [Kape](https://reddit.com/q3lepv).
-- FrostWire - [Adware](https://www.virustotal.com/gui/file/f20d66b647f15a5cd5f590b3065a1ef2bcd9dad307478437766640f16d416bbf/detection).
-- GShade - [Reinicia](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
-- McAfee - Instala bloatware.
-- PolyMC - O dono [expulsou todos os membros](https://www.reddit.com/y6lt6s) do servidor do Discord e repositório.
-- TLauncher - Práticas comerciais [questionáveis](https://www.reddit.com/zmzzrt).
+- μTorrent
+  - Tem anúncios e rastreadores e [é inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- Avast
+  - Conhecida por vender dados dos usuários.
+- AVG/CCleaner
+  - Propriedade da Avast.
+- BitComet/Bittorent
+  - Adware
+- BitLord
+  - [Adware](https://www.virustotal.com/gui/file/3ad1aed8bd704152157ac92afed1c51e60f205fbdce1365bad8eb9b3a69544d0)
+- CyberGhost/ExpressVPN/Private Internet Access/ZenMate
+  - [Propriedade](https://rentry.co/i8dwr) da [Kape](https://reddit.com/q3lepv).
+- FrostWire
+  - [Adware](https://www.virustotal.com/gui/file/f20d66b647f15a5cd5f590b3065a1ef2bcd9dad307478437766640f16d416bbf/detection)
+- GShade
+  - [Reinicia](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
+- McAfee
+  - Instala bloatware.
+- PolyMC
+  - O dono [expulsou todos os membros](https://www.reddit.com/y6lt6s) do servidor do Discord e repositório.
+- TLauncher
+  - Práticas comerciais [questionáveis](https://www.reddit.com/zmzzrt).

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -16,7 +16,7 @@ Transferências diretas são transferências normais por um servidor, sendo mais
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - Para jogos da GOG. Requer o [Tor Browser](https://www.torproject.org/download) para visitar.
 - [Ova Games](https://www.ovagames.com) - Senha dos arquivos: ``www.ovagames.com``.
 - [ReleaseBB](https://rlsbb.ru/category/games/pc) - Para lançamentos P2P e da cena.
-- [GLOAD](https://gload.to) - Para lançamentos P2P e da cena.
+- [GLOAD](https://gload.to/pc) - Para lançamentos P2P e da cena.
 - [Game-2U](https://game-2u.com/Category/game/pc)
 - [Seven Gamers](https://www.seven-gamers.com) - Tem links do Google Drive e torrent. Entre no [servidor do Discord deles](https://discord.com/invite/bzJkrxXXR2) por 1 dia para acessar os links do Google Drive.
 - [GameDrive](https://gamedrive.org)
@@ -59,20 +59,17 @@ Repacks são jogos compactados para usuários com pouca largura de banda, mas os
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
 - [🌟 ElAmigos](https://elamigos.site) - Transferências lentas para usyários grátis. Use os espelhos do GLOAD ou Ova Games em vez disso.
 - [🌟 KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- [Chovka](http://rutor.info/browse/0/8/1642915/0) - Também pode ser achado no [Repack.info](https://repack.info).
+- [R.G. Mechanics](https://tapochek.net/viewforum.php?f=808)
+- [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site) -  Para seus repacks de até maio de 2022. Mudou-se para o KaOsKrew em junho de 2022.
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- RG Mechanics
 - [Xatab](https://otxatabs.net)
 - [Darck Repacks](https://darckrepacks.com)
-- [Chovka](https://repack.info)
-- Masquerade Repacks (mudou-se para o KaOsKrew)
 - [Tiny Repacks](https://www.tiny-repacks.win)
 - [ZAZIX](https://1337x.to/user/ZAZIX/)
 - [Gnarly Repacks](https://gnarly-repacks.site) - Para jogos de console emulados.
 - [KAPITALSIN](https://kapitalsin.com/forum) - Para repacks com perdas (de menor qualidade e/ou com arquivos removidos). Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
-- R.G. Catalyst
-- R.G. Revenants
-- Mr DJ
 - [MagiPack Games](https://www.magipack.games) - Para jogos antigos.
 - [The Collection Chamber](https://collectionchamber.blogspot.com) - Para jogos antigos.
 - [CPG Repacks](https://cpgrepacks.site) - Para jogos de anime +18.
@@ -81,7 +78,7 @@ Repacks são jogos compactados para usuários com pouca largura de banda, mas os
 Não são para jogos online. Sem trapaças em jogos online!
 
 - [🌟 FLiNG Trainer](https://flingtrainer.com)
-- [🌟 GameCopyWorld](https://gamecopyworld.com/games) - Também tem só o crack e correções de NoCD.
+- [🌟 GameCopyWorld](https://gamecopyworld.com/games) - Também tem só os cracks e correções de NoCD.
 - [WeMod](https://www.wemod.com)
 - [MegaGames](https://megagames.com)
 - [FearLess Cheat Engine](https://fearlessrevolution.com) - Tem tabelas do Cheat Engine.

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -8,7 +8,7 @@ Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
 ### Sites de Transferências Diretas
-Transferências diretas são mais seguras e não requerem uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
+Transferências diretas são transferências normais por um servidor, sendo mais seguras e não requerindo uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
 
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registro requerido. O [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado. Use o [Baidu Bypass](https://baidu.crackhub.site) para links do Baidu. Senha: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
@@ -17,12 +17,12 @@ Transferências diretas são mais seguras e não requerem uma VPN. Você deve pr
 - [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - Para repacks da FitGirl e lançamentos da cena.
 - [CrackHub [Scene Games]](https://scene.crackhub.site) - Para lançamentos da cena do crackhub213.
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
 - [G4U](https://g4u.to) - Transferências lentas para usuários grátis. Senha: ``404``.
 - [Game-2U](https://game-2u.com) - Para jogos de PlayStation 4.
 - [GameDrive](https://gamedrive.org)
 - [GLOAD](https://gload.to) - Para lançamentos da cena.
-- [Seven Gamers](https://www.seven-gamers.com) - Tem links do Google Drive e torrent. Entre no servidor do Discord deles por 1 dia para acessar os links do Google Drive.
+- [Seven Gamers](https://www.seven-gamers.com) - Tem links do Google Drive e torrent. Entre no [servidor do Discord deles](https://discord.com/invite/bzJkrxXXR2) por 1 dia para acessar os links do Google Drive.
 - [ReleaseBB](https://rlsbb.ru/category/games)
 - [Scnlog](https://scnlog.me/games)
 - [Gamdie](https://gamdie.com) - Para jogos indie.
@@ -98,7 +98,7 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [PreDB.pw](https://predb.pw)
 - [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - Só para repacks.
-- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - Só para repacks. Subreddit irmão do [r/PiratedGames](https://www.reddit.com/r/PiratedGames)'.
+- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - Só para repacks. Subreddit irmão do [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
 
 ### Sites de ROMs
 

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -7,18 +7,18 @@ Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
-### Sites de Transferência Direta
-Transferências diretas são mais seguras e não requerem uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a seção de gerenciadores de transferências mais abaixo para ajuda no gerenciamento de suas transferências.
+### Sites de Transferências Diretas
+Transferências diretas são mais seguras e não requerem uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
 
-- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registro requerido. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado. Use o [Baidu Bypass](https://baidu.crackhub.site) para links do Baidu. Senha: ``cs.rin.ru``.
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registro requerido. O [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado. Use o [Baidu Bypass](https://baidu.crackhub.site) para links do Baidu. Senha: ``cs.rin.ru``.
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - Para jogos da GOG. Requer o [Tor Browser](https://www.torproject.org/download) para visitar.
 - [Ova Games](https://www.ovagames.com)
 - [CrackHub](https://crackhub.site) - Para repacks da FitGirl e lançamentos da cena.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - Para lançamentos da cena do crackhub213's.
+- [CrackHub [Scene Games]](https://scene.crackhub.site) - Para lançamentos da cena do crackhub213.
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
-- [G4U](https://g4u.to) - Transferências lentas para usuários gratuitos. Senha: ``404``.
+- [G4U](https://g4u.to) - Transferências lentas para usuários grátis. Senha: ``404``.
 - [Game-2U](https://game-2u.com) - Para jogos de PlayStation 4.
 - [GameDrive](https://gamedrive.org)
 - [GLOAD](https://gload.to) - Para lançamentos da cena.
@@ -27,9 +27,9 @@ Transferências diretas são mais seguras e não requerem uma VPN. Você deve pr
 - [Scnlog](https://scnlog.me/games)
 - [Gamdie](https://gamdie.com) - Para jogos indie.
 - [Leechinghell](http://www.leechinghell.pw) - Para jogos multijogador LAN.
-- [AppKed](https://www.macbed.com/games) - Para aplicativos e jogos de macOS.
-- [Mobilism](https://forum.mobilism.me) - Para aplicativos e jogos de Android.
-- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - Para aplicativos e jogos de iOS.
+- [AppKed](https://www.macbed.com/games) - Para jogos e aplicativos de macOS.
+- [Mobilism](https://forum.mobilism.me) - Para jogos e aplicativos de Android.
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - Para jogos e aplicativos de iOS.
 - [My Abandonware](https://www.myabandonware.com) - Para jogos antigos.
 - [Old Games Download](https://oldgamesdownload.com) - Para jogos antigos.
 - [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - Para jogos antigos.
@@ -40,8 +40,8 @@ Transferências diretas são mais seguras e não requerem uma VPN. Você deve pr
 - [PollyMC](https://github.com/fn2006/PollyMC) - Para Minecraft.
 - [Torrminatorr Forum](https://forum.torrminatorr.com) - Para jogos da GOG e de Linux e lançamentos da cena. Registro requerido. Fora do ar atualmente.
 
-### Sites de Torrent
-Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a seção de VPN mais abaixo para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.
+### Sites de Torrents
+Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a [seção de VPNs](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#vpns) para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/) - Evite torrents enviados pela IGG Games. Os scripts [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format) e [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) são recomendados.
 - [🌟 RARBG](https://rarbg.to) - Os scripts [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks) e [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) são recomendados.
@@ -108,12 +108,12 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [Edge Emulation](https://edgeemu.net)
 - [ROMSPURE](https://romspure.cc)
 - [The ROM Depot](https://theromdepot.com) - Registro requerido.
-- [Ziperto](https://www.ziperto.com) - Para jogos de Nintendo 3DS e Switch.
+- [Ziperto](https://www.ziperto.com) - Para jogos de Nintendo Switch e 3DS.
 - [NXBrew](https://nxbrew.com) - Para jogos de Nintendo Switch.
 - [r/Roms](https://www.reddit.com/r/roms)
 - [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Siga [este guia](https://www.reddit.com/120c0du) para baixar.
 
-### Programas de Transferência Direta
+### Gerenciadores de Transferências
 
 - [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detecta links da maioria dos hospedeiros de arquivos. Siga [este guia](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) para o melhorar. Evite mais CAPTCHAs com o [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). Veja [isto](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) para um tema escuro.
 - [Motrix](https://motrix.app)
@@ -122,7 +122,7 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
 
-### Programas de Torrent
+### Clientes de Torrents
 
 - [🌟 qBittorrent](https://www.qbittorrent.org) - O [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) é recomendado. Veja [isto](https://draculatheme.com/qbittorrent) para um tema escuro.
 - [🌟 Transmission](https://transmissionbt.com)
@@ -135,17 +135,17 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 
 ### Ferramentas
 
-- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Desbloqueador de DLCs de jogos legítimos. Use o [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) para configuração automática ou o [CreamInstaller](https://github.com/pointfeev/CreamInstaller) para instalação automática.
+- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Desbloqueador de DLCs de jogos legítimos da Steam. Use o [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) para configuração automática ou o [CreamInstaller](https://github.com/pointfeev/CreamInstaller) para instalação automática.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Desbloqueador de DLCs da Steam, Epic Games Store, dos clientes da EA e da Uplay.
 - [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Emulador da Steam. Use o [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) para o gerenciar com uma IU.
 - [Steamless](https://github.com/atom0s/Steamless) - Removedor da DRM SteamStub. Use o [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) para crackear automaticamente com o Goldberg Steam Emulator e o Steamless.
 - [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Criador automático de correções para o Steamworks.
 - [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Lista de ferramentas da Steam.
-- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Emulador da Uplay.
-- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Desbloqueador de DLCs dos clientes da EA e da Epic Games Store, Steam e Uplay.
-- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - Desbloqueadores de DLCs dos clientes da EA e da Epic Games Store.
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - Desbloqueador de DLCs dos clientes da EA.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - Desbloqueador de DLCs da Epic Games Store e dos clientes da EA.
 - [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Desbloqueador de DLCs da Epic Games Store.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - Desbloqueador de DLCs dos clientes da EA.
 - [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Emulador do Epic Online Services.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Emulador da Uplay.
 - [Online Fix](https://online-fix.me) - Permite jogar jogos pirateados online com outras cópias pirateadas. Senha: ``online-fix.me``.
 - [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Atualizador da versão pirata de The Sims 4.
 - [Lucky Patcher](https://www.luckypatchers.com) - Remendador de aplicativos de Android (melhor com root).
@@ -154,26 +154,26 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 
 > :exclamation: **Veja a [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) para nais.**
 
-- [Bsnes](https://github.com/bsnes-emu/bsnes) - Para jogos de Super Nintendo Entertainment System.
+- [RetroArch](https://retroarch.com) - Para jogos de vários consoles.
+- [Ryujinx](https://ryujinx.org) - Para jogos de Nintendo Switch.
+- [yuzu](https://yuzu-emu.org) - Para jogos de Nintendo Switch.
 - [Cemu](https://cemu.info) - Para jogos de Nintendo Wii U.
 - [Citra](https://citra-emu.org) - Para jogos de Nintendo 3DS.
-- [DeSmuME](https://desmume.org) - Para jogos de Nintendo DS.
-- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos de Nintendo GameCube e Wii.
-- [DuckStation](https://www.duckstation.org) - Para jogos de PlayStation 1.
-- [MAME](https://www.mamedev.org) - Para jogos de arcade.
-- [MelonDS](https://melonds.kuribo64.net) - Para jogos de Nintendo DS.
-- [mGBA](https://mgba.io) - Para jogos de Game Boy Advance.
-- [No$GBA](https://www.nogba.com) - Para jogos de Game Boy Advance e Nintendo DS.
-- [PCSX2](https://pcsx2.net) - Para jogos de PlayStation 2.
-- [PPSSPP](https://www.ppsspp.org) - Para jogos de PlayStation Portable.
+- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos de Nintendo Wii e GameCube.
 - [RCPS3](https://rpcs3.net) - Para jogos de PlayStation 3.
-- [RetroArch](https://retroarch.com) - Para jogos de vários consoles.
+- [xenia](https://xenia.jp) - Para jogos de Xbox 360.
+- [MAME](https://www.mamedev.org) - Para jogos de arcade.
+- [PPSSPP](https://www.ppsspp.org) - Para jogos de PlayStation Portable.
+- [melonDS](https://melonds.kuribo64.net) - Para jogos de Nintendo DS.
+- [DeSmuME](https://desmume.org) - Para jogos de Nintendo DS.
+- [No$GBA](https://www.nogba.com) - Para jogos de Nintendo DS e Game Boy Advance.
+- [xemu](https://xemu.app) - Para jogos de Xbox original.
+- [mGBA](https://mgba.io) - Para jogos de Game Boy Advance.
+- [PCSX2](https://pcsx2.net) - Para jogos de PlayStation 2.
 - [RMG](https://github.com/Rosalie241/RMG) - Para jogos de Nintendo 64.
-- [Ryujinx](https://ryujinx.org) - Para jogos de Nintendo Switch.
+- [DuckStation](https://www.duckstation.org) - Para jogos de PlayStation 1.
+- [bsnes](https://github.com/bsnes-emu/bsnes) - Para jogos de Super Nintendo Entertainment System.
 - [Snes9x](https://www.snes9x.com) - Para jogos de Super Nintendo Entertainment System.
-- [Xemu](https://xemu.app) - Para jogos de Xbox original.
-- [Xenia](https://xenia.jp) - Para jogos de Xbox 360.
-- [Yuzu](https://yuzu-emu.org) - Para jogos de Nintendo Switch.
 
 ### Programas Úteis
 
@@ -196,7 +196,7 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 
 ### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
-- [Recomendações do Privacy Guides de VPN](https://www.privacyguides.org/vpn)
+- [Recomendações do Privacy Guides de VPNs](https://www.privacyguides.org/vpn)
 - [Tabela de Comparação de VPNs](https://www.reddit.com/m736zt)
 
 > :warning: **Tor Browser ≠ VPN, sem proteção ao torrentear!**
@@ -211,8 +211,8 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
 - [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
-### Sites e Enviadores Não Confi
-Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) para bloquar a maioria dos sites mencionados aqui e mais. Siga [este guia](https://www.reddit.com/125a5xb) para adicionar o filtro customizado ao uBlock Origin.
+### Sites e Enviadores Não Confiáveis
+Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) para bloquear a maioria dos sites mencionados aqui e mais. Siga [este guia](https://www.reddit.com/125a5xb) para adicionar o filtro customizado ao uBlock Origin.
 
 > :warning: **GRUPOS DA CENA NÃO TÊM SITES! Todo site com o nome dum grupo da cena na URL é falso.**
 - AGFY - Anúncios de redirecionamento maliciosos.
@@ -227,12 +227,12 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 - Game3rb
 - Games Releaser
 - GOG Unlocked/SteamUnlocked - Jogos roubados da IGG Games e nosTEAM, anúncios de redirecionamento maliciosos e transferências lentas.
-- IGG Games/PCGamesTorrents - Fz doxing com o mercs213 (dono do Good Old Downloads), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
+- IGG Games/PCGamesTorrents - Fez doxing com o mercs213 (dono do Good Old Downloads), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
 - MrPcGames
 - NexusGames - Pego com malware.
 - nosTEAM
 - Ocean of Games - Constantemente pego com malware.
-- Qoob/Seyter - Pego com mineradores de criptomodas e [tentou trocar de mome](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
+- Qoob/Seyter - Pego com mineradores de criptomoedas e [tentou trocar de nome](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
 - Repack-Games - Rouba lançamentos e rotula os jogos errado.
 - Steam-Repacks - Pego com malware.
 - Steam Cracked
@@ -244,8 +244,8 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 
 ### Programas Inseguros
 
-- μTorrent - Tem anúncios e rastreadores e é [inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
-- Avast - Conhecida por venser dados dos usuários.
+- μTorrent - Tem anúncios e rastreadores e [é inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- Avast - Conhecida por vender dados dos usuários.
 - AVG/CCleaner - Propriedade da Avast.
 - BitComet/Bittorent - Adware.
 - BitLord - Adware.
@@ -253,6 +253,5 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 - FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
 - GShade - [Reinicia](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
 - McAfee - Instala bloatware.
-- now.gg - [Rouba](https://reddit.com/qu3j5q) contas.
-- PolyMC - Dono [expulsou todos os membros](https://reddit.com/y6lt6s) do servidor do Discord e repositório.
+- PolyMC - O dono [expulsou todos os membros](https://reddit.com/y6lt6s) do servidor do Discord e repositório.
 - TLauncher - Práticas comerciais [questionáveis](https://reddit.com/zmzzrt).

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -254,5 +254,5 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 - GShade - [Reinicia](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
 - McAfee - Instala bloatware.
 - now.gg - [Rouba](https://reddit.com/qu3j5q) contas.
-- PolyMC - Dono [expulsou tooos os membros](https://reddit.com/y6lt6s) do servidor do Discord e repositório.
+- PolyMC - Dono [expulsou todos os membros](https://reddit.com/y6lt6s) do servidor do Discord e repositório.
 - TLauncher - Práticas comerciais [questionáveis](https://reddit.com/zmzzrt).

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -1,234 +1,258 @@
-**Aqui Está a Megathread do /r/PiratedGames!** - [Traduções](translations)
----
+## **Aqui Está a Megathread do /r/PiratedGames** - [Traduções](translations)
 
-### Componentes Precisos:
-Você terá de instalar tudo isto antes de baixar qualquer jogo (legítimo ou pirata) para parar falhas devido a programas faltando em seu computador:
+### Componentes Requeridos
+Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas devido a programas faltando no seu computador.
 
 - [DirectX](https://www.microsoft.com/download/details.aspx?id=35)
 - [VisualCppRedist AIO](https://github.com/abbodi1406/vcredist/releases/latest)
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
-### Subreddits Relacionados:
+### Sites de Transferência Direta
+Transferências diretas são mais seguras e não requerem uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a seção de gerenciadores de transferências mais abaixo para ajuda no gerenciamento de suas transferências.
 
-- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
-- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
-- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
-- [r/Piracy](https://www.reddit.com/r/Piracy)
-- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
-- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
-
-### Sites de Torrents:
-Você provavelmente precisará duma VPN para baixar torrents para evitar receber avisos de direitos autorais de seu provedor, a menos que seu país não se importe com a pirataria. Leia mais na seção VPN, mais abaixo na thread. Os torrents são transferências P2P: Você baixa doutras pessoas que baixaram o arquivo. Nenhum servidor está envolvido.
-
-- [1337x](https://1337x.to) - Não baixe torrents enviados pelo IGGGAMES.
-- [NMac](https://nmac.to)
-- [RARBG](https://rarbg.to)
-- [RuTor](http://rutor.info)
-- [RuTracker](https://rutracker.org)
-- [Rustorka](https://rustorka.com/forum)
-- [Tapochek](https://tapochek.net)
-
-### Sites de Transferências Diretas:
-Transferências diretas são qualquer transferência normal: Você baixa o arquivo dum servidor através dum navegador. É significativamente mais seguro baixar nesta forma e você não precisará duma VPN. Você precisará duma VPN para acessar sites de hospedagem de arquivos bloqueados (por exemplo, o ZippyShare está bloqueado nalguns países da UE) nalguns casos. É recomendado usar um gerenciador de transferências mencionado mais abaixo na thread para ajudar a gerenciar suas transferências.
-
-- [AppCake](https://iphonecake.com) - Para apps e jogos de iOS.
-- [AppKed](https://www.macbed.com)
-- [Archive.org - Classic PC Games](https://archive.org/details/classicpcgames)
-- [CrackHub](https://crackhub.site) - Para jogos da cena e repacks da FitGirl.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - Para uploads da cena do CrackHub213.
-- [CS.RIN.RU](https://cs.rin.ru/forum)
-- [DOS Games Archive](https://www.dosgamesarchive.com)
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use o Google Tradutor.
-- [G4U](https://g4u.to)
-- [Game-2U](https://game-2u.com) - Para jogos de PlayStation 4 (use a [extensão FastForward](https://fastforward.team/install) para contornar encurtadores de links com anúncios).
-- [GamesDrive](https://gamesdrive.net)
-- [GLOAD](https://gload.to)
-- [GOG Games](https://gog-games.com)
+- [🌟 CS.RIN.RU](https://cs.rin.ru/forum) - Registro requerido. [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado. Use o [Baidu Bypass](https://baidu.crackhub.site) para links do Baidu. Senha: ``cs.rin.ru``.
+- [🌟 SteamRIP](https://steamrip.com)
+- [🌟 GamesDrive](https://gamesdrive.net)
+- [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - Para jogos da GOG. Requer o [Tor Browser](https://www.torproject.org/download) para visitar.
+- [Ova Games](https://www.ovagames.com)
+- [CrackHub](https://crackhub.site) - Para repacks da FitGirl e lançamentos da cena.
+- [CrackHub [Scene Games]](https://scene.crackhub.site) - Para lançamentos da cena do crackhub213's.
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [a translator](https://github.com/FilipePS/Traduzir-paginas-web).
+- [G4U](https://g4u.to) - Transferências lentas para usuários gratuitos. Senha: ``404``.
+- [Game-2U](https://game-2u.com) - Para jogos de PlayStation 4.
+- [GameDrive](https://gamedrive.org)
+- [GLOAD](https://gload.to) - Para lançamentos da cena.
+- [Seven Gamers](https://www.seven-gamers.com) - Tem links do Google Drive e torrent. Entre no servidor do Discord deles por 1 dia para acessar os links do Google Drive.
+- [ReleaseBB](https://rlsbb.ru/category/games)
+- [Scnlog](https://scnlog.me/games)
+- [Gamdie](https://gamdie.com) - Para jogos indie.
+- [Leechinghell](http://www.leechinghell.pw) - Para jogos multijogador LAN.
+- [AppKed](https://www.macbed.com/games) - Para aplicativos e jogos de macOS.
 - [Mobilism](https://forum.mobilism.me) - Para aplicativos e jogos de Android.
+- [AppCake](https://iphonecake.com/index.php?device=0&p=1&c=8) - Para aplicativos e jogos de iOS.
 - [My Abandonware](https://www.myabandonware.com) - Para jogos antigos.
 - [Old Games Download](https://oldgamesdownload.com) - Para jogos antigos.
-- [Online Fix](https://online-fix.me) - Para jogos multijogador online.
-- [Ova Games](https://www.ovagames.com)
-- [RLSBB](https://rlsbb.ru)
-- [Scnlog](https://scnlog.me)
-- [SKlauncher](https://skmedix.pl) - Para o Minecraft.
-- [SteamRIP](https://steamrip.com)
-- [Torrminatorr Forum](https://forum.torrminatorr.com)
+- [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - Para jogos antigos.
+- [The Collection Chamber](https://collectionchamber.blogspot.com) - Para jogos antigos, melhorados para funcionar em sistemas modernos.
+- [Old-Games.RU](https://www.old-games.ru/catalog/) - Para jogos antigos. Pode ser trocado para inglês no canto superior direito.
+- [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - Para HOGs. Registro requerido.
+- [DOS Games Archive](https://www.dosgamesarchive.com) - Para jogos de MS-DOS.
+- [PollyMC](https://github.com/fn2006/PollyMC) - Para Minecraft.
+- [Torrminatorr Forum](https://forum.torrminatorr.com) - Para jogos da GOG e de Linux e lançamentos da cena. Registro requerido. Fora do ar atualmente.
 
-### Trainers (Trapaças):
-Nota: Estes não são para jogos online. Não use trapaças em jogos online!
+### Sites de Torrent
+Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a seção de VPN mais abaixo para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.
 
-- [FearLess Cheat Engine](https://fearlessrevolution.com) - Tem tabelas do Cheat Engine.
-- [FLiNG Trainer](https://flingtrainer.com)
-- [GameCopyWorld](https://gamecopyworld.com/games) - Também tem correções de NoCD e só cracks.
-- [MrAntiFun](https://mrantifun.net)
-- [WeMod](https://www.wemod.com)
+- [🌟 1337x](https://1337x.to/sub/10/0/) - Evite torrents enviados pela IGG Games. Os scripts [Torrent Page Improvements](https://greasyfork.org/scripts/33379-1337x-torrent-page-improvements), [Torrent and Magnet Links](https://greasyfork.org/scripts/420754-1337x-torrent-and-magnet-links), [Convert Timestamps to Relative Format](https://greasyfork.org/scripts/421635-1337x-convert-torrent-timestamps-to-relative-format) e [Subtitle Download Links to TV and Movie Torrents](https://greasyfork.org/scripts/29467-1337x-subtitle-download-links-to-tv-and-movie-torrents) são recomendados.
+- [🌟 RARBG](https://rarbg.to) - Os scripts [Advanced Filters](https://greasyfork.org/scripts/29661-rarbg-advanced-filters), [Various Tweaks](https://greasyfork.org/scripts/367358-rarbg-various-tweaks) e [Torrent and Magnet Links](https://greasyfork.org/scripts/23493-rarbg-torrent-and-magnet-links) são recomendados.
+- [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Rutor](http://rutor.info/games) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Tapochek](https://tapochek.net/index.php?c=2) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [NMac](https://nmac.to/category/games) - Para aplicativos e jogos de macOS.
+- [Mac Torrents](https://www.torrentmac.net/category/games) - Para aplicativos e jogos de macOS.
+- [Mac Torrent](https://www.mactorrents.is/macos-games) - Para aplicativos e jogos de macOS.
 
-### Repacks:
-Repacks são jogos altamente compactados, projetados para pessoas com largura de banda de internet lenta e/ou limitada. Você deve os instalar em seu computador após os baixar, o que pode levar muito tempo devido à descompressão dos arquivos.
+### Repacks
+Repacks são jogos compactados para usuários com pouca largura de banda, mas os instalar demora mais devido à descompressão de arquivos.
 
+- [🌟 DODI Repacks](https://dodi-repacks.site)
+- [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
 - [Chovka](https://repack.info)
-- [CPG Repacks](https://cpgrepacks.site) 
-- [DODI Repacks](https://dodi-repacks.site)
 - [Darck Repacks](https://darckrepacks.com)
-- [ElAmigos](https://elamigos.site)
-- [FitGirl Repacks](https://fitgirl-repacks.site)
-- [Gnarly Repacks](https://gnarly-repacks.site)
-- [KaOsKrew](https://kaoskrew.org)
-- [KAPITALSIN](https://kapitalsin.com/forum)
-- [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- [ElAmigos](https://elamigos.site) - Transferências lentas para usuários grátis. Use os espelhos do GLOAD ou Ova Games em vez disso.
+- [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- [Xatab](https://otxatabs.net)
 - Masquerade Repacks (mudou-se para o KaOsKrew)
 - Mr DJ
 - R.G. Catalyst
 - R.G. Mechanics
 - R.G. Revenants
-- [Scooter Repacks](https://scooter-repacks.site)
-- [Tiny Repacks](https://www.tiny-repacks.win)
-- [Xatab](https://byxatab.com)
 - ZAZIX
+- [Gnarly Repacks](https://gnarly-repacks.site) - Para jogos de console emulados.
+- [KAPITALSIN](https://kapitalsin.com/forum) - Para repacks com perdas (com arquivos de menor qualidade e/ou removidos). Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Tiny Repacks](https://www.tiny-repacks.win) - Para jogos indie.
+- [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- [MagiPack Games](https://www.magipack.games) - Para jogos antigos.
+- [CPG Repacks](https://cpgrepacks.site) - Para jogos de anime +18.
 
-### Redes de Lançamentos:
-Nota: Nenhum destes sites fornece transferências, só informações sobre lançamentos da cena e/ou P2P. Buscando ver se um jogo foi crackeado? Verifique aqui!
+### Trainers (Trapaças)
+Não são para jogos online. Sem trapaças em jogos online!
 
-- [CrackForecast](https://www.reddit.com/r/CrackForecast) - Subreddit de brincadeira para responder à pergunta "Quando o jogo X será crackeado?"
-- [CrackWatch](https://www.reddit.com/r/CrackWatch)
-- [m2v.ru](https://m2v.ru)
-- [PreDB.de](https://predb.de)
-- [PreDB.me](https://predb.me/?cats=games-pc)
-- [PreDB.org](https://predb.org)
-- [PreDB.ovh](https://predb.ovh)
+- [🌟 FLiNG Trainer](https://flingtrainer.com)
+- [🌟 GameCopyWorld](https://gamecopyworld.com/games) - Também tem só o crack e correções de NoCD.
+- [WeMod](https://www.wemod.com)
+- [MegaGames](https://megagames.com)
+- [FearLess Cheat Engine](https://fearlessrevolution.com) - Tem tabelas do Cheat Engine.
+- [MrAntiFun](https://mrantifun.net)
+
+### Rastreadores de Lançamentos
+Sem transferências fornecidas. Os sites têm informações de lançamentos da cena/P2P. Veja aqui se um jogo foi crackeado!
+
+- [🌟 xREL](https://www.xrel.to/games-release-list.html?lang=en_US)
+- [m2v.ru](https://m2v.ru/?func=part&Part=3)
+- [PreDB.org](https://predb.org/cats/GAMES)
+- [PreDB.de](https://predb.de/section/GAMES)
+- [srrDB](https://www.srrdb.com/browse/category:pc/1)
 - [PreDB.pw](https://predb.pw)
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
 - [r/RepackWatchers](https://www.reddit.com/r/RepackWatchers) - Só para repacks.
-- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - Só para repacks. Subreddit irmão do [r/PiratedGames](https://www.reddit.com/r/PiratedGames).
-- [srrDB](https://www.srrdb.com)
-- [xREL](https://xrel.to)
+- [r/RepackWorld](https://www.reddit.com/r/RepackWorld) - Só para repacks. Subreddit irmão do [r/PiratedGames](https://www.reddit.com/r/PiratedGames)'.
 
-### Sites de ROMs:
+### Sites de ROMs
 
-- [CDRomance](https://cdromance.com)
+- [🌟 r/Roms Megathread](https://r-roms.github.io)
+- [🌟 Vimm's Lair](https://vimm.net/?p=vault)
+- [🌟 CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [Emuparadise](https://www.emuparadise.me) - Use [este script](https://www.reddit.com/r/Piracy/comments/968sm6/a_script_for_easy_downloading_of_emuparadise_roms) para baixar.
-- [Megathread do r/Roms](https://r-roms.github.io)
-- [NXBrew](https://nxbrew.com)
-- [The Eye](https://the-eye.eu)
-- [The ROM Depot](https://theromdepot.com)
-- [RomUlation](https://www.romulation.net)
-- [r/Roms](https://www.reddit.com/r/roms)
 - [ROMSPURE](https://romspure.cc)
-- [Vimm's Lair](https://vimm.net/?p=vault)
-- [Ziperto](https://www.ziperto.com)
+- [The ROM Depot](https://theromdepot.com) - Registro requerido.
+- [Ziperto](https://www.ziperto.com) - Para jogos de Nintendo 3DS e Switch.
+- [NXBrew](https://nxbrew.com) - Para jogos de Nintendo Switch.
+- [r/Roms](https://www.reddit.com/r/roms)
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Siga [este guia](https://www.reddit.com/120c0du) para baixar.
 
-### Emuladores:
+### Programas de Transferência Direta
 
-- [Bsnes](https://github.com/bsnes-emu/bsnes) - Para jogos do Super Nintendo Entertainment System.
-- [Cemu](https://cemu.info) - Para jogos do Nintendo Wii U.
-- [Citra](https://citra-emu.org) - Para jogos do Nintendo 3DS.
-- [DeSmuME](https://desmume.org) - Para jogos do Nintendo DS.
-- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos do Nintendo GameCube e Wii.
-- [DuckStation](https://www.duckstation.org) - Para jogos do PlayStation 1.
-- [ePSXe](https://epsxe.com) - Para jogos do PlayStation 1.
-- [Kega Fusion](https://www.carpeludum.com/kega-fusion) - Para jogos do Sega Mega Drive.
-- [MAME](https://www.mamedev.org) - Para jogos de arcade.
-- [MelonDS](https://melonds.kuribo64.net) - Para jogos do Nintendo DS.
-- [mGBA](https://mgba.io) - Para jogos do Game Boy Advance.
-- [No$GBA](https://www.nogba.com) - Para jogos do Game Boy Advance e Nintendo DS.
-- [Project64](https://www.pj64-emu.com) - Para jogos do Nintendo 64.
-- [PCSX2](https://pcsx2.net) - Para jogos do PlayStation 2.
-- [PPSSPP](https://www.ppsspp.org) - Para jogos do PlayStation Portable.
-- [RCPS3](https://rpcs3.net) - Para jogos do PlayStation 3.
-- [RetroArch](https://retroarch.com)
-- [Ryujinx](https://ryujinx.org) - Para jogos do Nintendo Switch.
-- [Snes9x](https://www.snes9x.com) - Para jogos do Super Nintendo Entertainment System.
-- [Xemu](https://xemu.app) - Para jogos do Xbox original.
-- [Xenia](https://xenia.jp) - Para jogos do Xbox 360.
-- [Yuzu](https://yuzu-emu.org) - Para jogos do Nintendo Switch.
-- [ZSNES](https://zsnes.com) - Para jogos do Super Nintendo Entertainment System.
-
-### Programas de Torrents:
-
-- [BiglyBT](https://www.biglybt.com)
-- [Deluge](https://dev.deluge-torrent.org)
-- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - Para dispositivos Android.
-- [PicoTorrent](https://picotorrent.org)
-- [qBittorrent](https://www.qbittorrent.org)
-- [Tixati](https://tixati.com)
-- [Transmission](https://transmissionbt.com)
-- [WebTorrent](https://webtorrent.io)
-
-### Programas de Transferências Diretas:
-
-- [Free Download Manager](https://www.freedownloadmanager.org)
-- [Internet Download Manager](https://internetdownloadmanager.com)
-- [JDownloader2](https://jdownloader.org/jdownloader2)
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detecta links da maioria dos hospedeiros de arquivos. Siga [este guia](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) para o melhorar. Evite mais CAPTCHAs com o [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). Veja [isto](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) para um tema escuro.
 - [Motrix](https://motrix.app)
+- [Free Download Manager](https://www.freedownloadmanager.org) - Use o [Elephant](https://github.com/meowcateatrat/elephant) para baixar vídeos.
+- [Internet Download Manager](https://internetdownloadmanager.com) -  O [IDMHelper](https://github.com/unamer/IDMHelper) é recomendado. Use o [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) para o usar para sempre.
+- [Xtreme Download Manager](https://github.com/subhra74/xdm)
 - [pyLoad](https://pyload.net)
-- [Xtreme Download Manager](https://xtremedownloadmanager.com)
 
-### Ferramentas:
+### Programas de Torrent
 
-- [Auto CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521#p2013521) - Configure automaticamente seu jogo para o CreamAPI.
-- [Auto Steamworks Fix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Crie automaticamente correções para o Steamworks.
-- [CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Desbloqueie DLCs piratas em jogos legítimos da Steam.
-- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627)
-- [Lucky Patcher](https://www.luckypatchers.com) - Remende aplicativos de Android (melhor com root).
-- [LumaPlay (para o Uplay)](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197)
-- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551)
-- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412)
-- [RIN SteamInternals - A Broad Collection of Steam Tools](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887)
-- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Ferramenta de atualização para a versão pirata do The Sims 4.
-- [Steamless](https://github.com/atom0s/Steamless)
+- [🌟 qBittorrent](https://www.qbittorrent.org) - O [qBittorent Enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition) é recomendado. Veja [isto](https://draculatheme.com/qbittorrent) para um tema escuro.
+- [🌟 Transmission](https://transmissionbt.com)
+- [Deluge](https://dev.deluge-torrent.org)
+- [Tixati](https://tixati.com)
+- [Motrix](https://motrix.app)
+- [PicoTorrent](https://picotorrent.org)
+- [BiglyBT](https://www.biglybt.com)
+- [LibreTorrent](https://github.com/proninyaroslav/libretorrent) - Para dispositivos Android.
 
-### Programas Úteis:
+### Ferramentas
 
-- [7-Zip](https://7-zip.org)
-- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher)
+- [🌟 CreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=70576) - Desbloqueador de DLCs de jogos legítimos. Use o [Auto-CreamAPI](https://cs.rin.ru/forum/viewtopic.php?p=2013521) para configuração automática ou o [CreamInstaller](https://github.com/pointfeev/CreamInstaller) para instalação automática.
+- [Goldberg Steam Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=91627) - Emulador da Steam. Use o [GolgbergGUI](https://cs.rin.ru/forum/viewtopic.php?f=29&t=111152) para o gerenciar com uma IU.
+- [Steamless](https://github.com/atom0s/Steamless) - Removedor da DRM SteamStub. Use o [Steam Game Automatic Cracker](https://github.com/oureveryday/Steam-auto-crack) para crackear automaticamente com o Goldberg Steam Emulator e o Steamless.
+- [Auto SteamFix Tool](https://cs.rin.ru/forum/viewtopic.php?f=29&t=97112) - Criador automático de correções para o Steamworks.
+- [RIN SteamInternals](https://cs.rin.ru/forum/viewtopic.php?f=10&t=65887) - Lista de ferramentas da Steam.
+- [LumaPlay](https://cs.rin.ru/forum/viewtopic.php?f=29&t=67197) - Emulador da Uplay.
+- [Koalageddon](https://github.com/acidicoala/Koalageddon) - Desbloqueador de DLCs dos clientes da EA e da Epic Games Store, Steam e Uplay.
+- [DreamAPI](https://cs.rin.ru/forum/viewtopic.php?f=10&t=111520) - Desbloqueadores de DLCs dos clientes da EA e da Epic Games Store.
+- [EA DLC Unlocker](https://cs.rin.ru/forum/viewtopic.php?f=20&t=104412) - Desbloqueador de DLCs dos clientes da EA.
+- [ScreamAPI](https://github.com/acidicoala/ScreamAPI) - Desbloqueador de DLCs da Epic Games Store.
+- [Nemirtingas Epic Emulator](https://cs.rin.ru/forum/viewtopic.php?f=29&t=105551) - Emulador do Epic Online Services.
+- [Online Fix](https://online-fix.me) - Permite jogar jogos pirateados online com outras cópias pirateadas. Senha: ``online-fix.me``.
+- [Sims 4 Updater](https://cs.rin.ru/forum/viewtopic.php?f=29&t=102519) - Atualizador da versão pirata de The Sims 4.
+- [Lucky Patcher](https://www.luckypatchers.com) - Remendador de aplicativos de Android (melhor com root).
+
+### Emuladores
+
+> :exclamation: **Veja a [Emulation General Wiki](https://emulation.gametechwiki.com/index.php/Main_Page#Emulators) para nais.**
+
+- [Bsnes](https://github.com/bsnes-emu/bsnes) - Para jogos de Super Nintendo Entertainment System.
+- [Cemu](https://cemu.info) - Para jogos de Nintendo Wii U.
+- [Citra](https://citra-emu.org) - Para jogos de Nintendo 3DS.
+- [DeSmuME](https://desmume.org) - Para jogos de Nintendo DS.
+- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos de Nintendo GameCube e Wii.
+- [DuckStation](https://www.duckstation.org) - Para jogos de PlayStation 1.
+- [MAME](https://www.mamedev.org) - Para jogos de arcade.
+- [MelonDS](https://melonds.kuribo64.net) - Para jogos de Nintendo DS.
+- [mGBA](https://mgba.io) - Para jogos de Game Boy Advance.
+- [No$GBA](https://www.nogba.com) - Para jogos de Game Boy Advance e Nintendo DS.
+- [PCSX2](https://pcsx2.net) - Para jogos de PlayStation 2.
+- [PPSSPP](https://www.ppsspp.org) - Para jogos de PlayStation Portable.
+- [RCPS3](https://rpcs3.net) - Para jogos de PlayStation 3.
+- [RetroArch](https://retroarch.com) - Para jogos de vários consoles.
+- [RMG](https://github.com/Rosalie241/RMG) - Para jogos de Nintendo 64.
+- [Ryujinx](https://ryujinx.org) - Para jogos de Nintendo Switch.
+- [Snes9x](https://www.snes9x.com) - Para jogos de Super Nintendo Entertainment System.
+- [Xemu](https://xemu.app) - Para jogos de Xbox original.
+- [Xenia](https://xenia.jp) - Para jogos de Xbox 360.
+- [Yuzu](https://yuzu-emu.org) - Para jogos de Nintendo Switch.
+
+### Programas Úteis
+
+- [7-Zip](https://7-zip.org) - Arquivador de arquivos.
 - [Bitwarden](https://bitwarden.com) - Gerenciador de senhas de código aberto.
+- [Tor Browser](https://www.torproject.org) - O navegador mais privado.
+- [Achievement Watcher](https://xan105.github.io/Achievement-Watcher) - Analisador de arquivos de conquistas com capturas de tela automáticas, rastreamento de tempo de jogo e notificações em tempo real.
 - [Parsec](https://parsec.app) - Jogue jogos multijogador local de qualquer lugar.
-- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Verifique somas de verificação e gere informações de hash.
-- [Tor Browser](https://www.torproject.org)
-- [WinRAR](https://www.rarlab.com)
+- [RapidCRC](https://ov2.eu/programs/rapidcrc-unicode) - Verificador de soma de verificação e gerador de informações de hash.
 
-**Você pode usar o [MAS](https://github.com/massgravel/Microsoft-Activation-Scripts) para ativar produtos da Microsoft (Office e Windows).**
+> :memo: **Use o [Microsoft Activation Scripts](https://github.com/massgravel/Microsoft-Activation-Scripts) para ativar produtos da Microsoft (Office e Windows).**
 
-**Visite o [m0nkrus](https://w14.monkrus.ws) para produtos da Adobe.**
+> :memo: **Visite o [m0nkrus](https://w14.monkrus.ws) para produtos da Adobe.**
 
-### Extensões de Navegador Úteis:
+### Extensões de Navegador Úteis
 
-- [FastForward](https://fastforward.team)
-- [uBlock Origin](https://ublockorigin.com)
+- [uBlock Origin](https://ublockorigin.com) - Bloqueador de conteúdo de anúncio. Seguir as [recomendações do Privacy Guides](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) é recomendado.
+- [FastForward](https://fastforward.team) - Contornador de encurtadores de links.
+- [AdNauseam](https://adnauseam.io) - Bloqueador de conteúdo de anúncio baseado no uBlock Origin que também ofusca os dados de navegação.
 
-### VPNs:
+### VPNs
 - [r/VPN](https://www.reddit.com/r/VPN)
-- [Recomendações de VPN do Privacy Guides](https://www.privacyguides.org/vpn)
-- [Tabela de Comparação de VPNs no r/VPN](https://www.reddit.com/r/VPN/comments/m736zt/vpn_comparison_table)
+- [Recomendações do Privacy Guides de VPN](https://www.privacyguides.org/vpn)
+- [Tabela de Comparação de VPNs](https://www.reddit.com/m736zt)
 
-**Tor NÃO é uma VPN, ele não o protegerá ao torrentear!**
+> :warning: **Tor Browser ≠ VPN, sem proteção ao torrentear!**
 
-### Programas Não Seguros:
+### Subreddits Relacionados
 
-- μTorrent - O mesmo que Bittorrent: Tem anúncios e rastreadores e não é seguro.
-- Avast - Notório por coletar e vender dados de usuários.
-- BitTorrent - O mesmo que μTorrent: Tem anúncios e rastreadores e não é seguro.
-- CCleaner - Pertence à Avast.
+- [r/FREEMEDIAHECKYEAH](https://www.reddit.com/r/FREEMEDIAHECKYEAH)
+- [r/Piracy](https://www.reddit.com/r/Piracy)
+- [r/CrackSupport](https://www.reddit.com/r/CrackSupport)
+- [r/CrackWatch](https://www.reddit.com/r/CrackWatch)
+- [r/LinuxCrackSupport](https://www.reddit.com/r/LinuxCrackSupport)
+- [r/QuestPiracy](https://www.reddit.com/r/QuestPiracy)
+- [r/SwitchPirates](https://www.reddit.com/r/SwitchPirates)
 
-### Sites e Uploaders Não Confiáveis:
+### Sites e Enviadores Não Confi
+Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) para bloquar a maioria dos sites mencionados aqui e mais. Siga [este guia](https://www.reddit.com/125a5xb) para adicionar o filtro customizado ao uBlock Origin.
 
-- AGFY - Links de fraude.
+> :warning: **GRUPOS DA CENA NÃO TÊM SITES! Todo site com o nome dum grupo da cena na URL é falso.**
+- AGFY - Anúncios de redirecionamento maliciosos.
+- AimHaven - Anúncios de redirecionamento maliciosos.
+- AllTorrents
 - ApunKaGames
-- cracked-games - Risco de malware.
-- CrackingPatching - Risco de malware.
-- Downloadly - Contém mineradores de cripto.
-- GOG Unlocked/SteamUnlocked - Redidrecionamentos de links maliciosos, transferências lentas e uploads roubados do IGGGames.
-- IGGGAMES/PCGamesTorrents - Eles fizeram doxing com o mercs213 (dono do Good Old Downloads), exploram você para obter receitas de anúncios e embalam seu próprio DRM em jogos indie.
-- NexusGames - Transferências maliciosas.
+- cracked-games/GETGAMEZ - Pego com malware.
+- CrackingPatching - Pego com [malware](https://reddit.com/qy6z3c).
+- Downloadly - Pego com mineradores de criptomoedas.
+- Free GOG PC Games - Modifica as DLLs com [anúncios da IGG Games](https://reddit.com/r/Piracy/comments/zz6z77/megathread_clarification/j5c9ikd).
+- FreeTP
+- Game3rb
+- Games Releaser
+- GOG Unlocked/SteamUnlocked - Jogos roubados da IGG Games e nosTEAM, anúncios de redirecionamento maliciosos e transferências lentas.
+- IGG Games/PCGamesTorrents - Fz doxing com o mercs213 (dono do Good Old Downloads), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
+- MrPcGames
+- NexusGames - Pego com malware.
 - nosTEAM
-- Ocean of Games - Alto risco de malware.
-- Repack-Games - Rotulam mal os jogos e roubam lançamentos.
-- Seyter - Repacks contém mineradores de bitcoin.
-- Steam-Repacks - Transferências maliciosas.
-- The Pirate Bay - Risco de malware.
-- WIFI4Games - Transferências maliciosas.
-- Worldofpcgames - Transferências maliciosas.
-- xGIROx - Repacks contém mineradores de bitcoin.
-- Qualquer site com o nome dum grupo da cena na URL - **GRUPOS DA CENA NÃO TÊM SITES!**
+- Ocean of Games - Constantemente pego com malware.
+- Qoob/Seyter - Pego com mineradores de criptomodas e [tentou trocar de mome](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j4d2dld).
+- Repack-Games - Rouba lançamentos e rotula os jogos errado.
+- Steam-Repacks - Pego com malware.
+- Steam Cracked
+- The Pirate Bay - Alto risco de malware devido a nenhuma moderação.
+- Unlocked-Games
+- WIFI4Games - Pego com malware.
+- Worldofpcgames - Pego com malware.
+- xGIROx - Pego com mineradores de criptomoedas.
+
+### Programas Inseguros
+
+- μTorrent - Tem [anúncios e tastreadores e é inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- Avast - Conhecida por venser dados dos usuários.
+- AVG/CCleaner - Propriedade da Avast.
+- BitComet/Bittorent - Adware.
+- BitLord - Adware.
+- CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Propriedade](https://rentry.co/i8dwr) da [Kape](https://reddit.com/q3lepv).
+- FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
+- GShade - [Reinicia seu computador ao usar aplicativos de atualização de terceiros](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt).
+- McAfee - Instala bloatware.
+- now.gg - Rouba contas.
+- PolyMC - Owner [kicked all members](https://reddit.com/y6lt6s) from Discord server and repository.
+- TLauncher - Práticas comerciais [questionáveis](https://reddit.com/zmzzrt).

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -14,17 +14,17 @@ Transferências diretas são transferências normais por um servidor, sendo mais
 - [🌟 SteamRIP](https://steamrip.com)
 - [🌟 GamesDrive](https://gamesdrive.net)
 - [🌟 GOG Games](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion) - Para jogos da GOG. Requer o [Tor Browser](https://www.torproject.org/download) para visitar.
-- [Ova Games](https://www.ovagames.com)
-- [CrackHub](https://crackhub.site) - Para repacks da FitGirl e lançamentos da cena.
-- [CrackHub [Scene Games]](https://scene.crackhub.site) - Para lançamentos da cena do crackhub213.
-- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [G4U](https://g4u.to) - Transferências lentas para usuários grátis. Senha: ``404``.
-- [Game-2U](https://game-2u.com) - Para jogos de PlayStation 4.
-- [GameDrive](https://gamedrive.org)
-- [GLOAD](https://gload.to) - Para lançamentos da cena.
+- [Ova Games](https://www.ovagames.com) - Senha dos arquivos: ``www.ovagames.com``.
+- [ReleaseBB](https://rlsbb.ru/category/games/pc) - Para lançamentos P2P e da cena.
+- [GLOAD](https://gload.to) - Para lançamentos P2P e da cena.
+- [Game-2U](https://game-2u.com/Category/game/pc)
 - [Seven Gamers](https://www.seven-gamers.com) - Tem links do Google Drive e torrent. Entre no [servidor do Discord deles](https://discord.com/invite/bzJkrxXXR2) por 1 dia para acessar os links do Google Drive.
-- [ReleaseBB](https://rlsbb.ru/category/games)
-- [Scnlog](https://scnlog.me/games)
+- [GameDrive](https://gamedrive.org)
+- [G4U](https://g4u.to) - Transferências lentas para usuários grátis. Senha: ``404``.
+- [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game) - Transferências lentas. Senha: ``www.downloadha.com``. Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Scnlog](https://scnlog.me/games) - Para lançamentos da cena.
+- [CrackHub [Jogos da Cena]](https://scene.crackhub.site) - Para lançamentos da cena.
+- [CrackHub](https://crackhub.site) - Para lançamentos P2P e da cena.
 - [Gamdie](https://gamdie.com) - Para jogos indie.
 - [Leechinghell](http://www.leechinghell.pw) - Para jogos multijogador LAN.
 - [AppKed](https://www.macbed.com/games) - Para jogos e aplicativos de macOS.
@@ -33,7 +33,6 @@ Transferências diretas são transferências normais por um servidor, sendo mais
 - [My Abandonware](https://www.myabandonware.com) - Para jogos antigos.
 - [Old Games Download](https://oldgamesdownload.com) - Para jogos antigos.
 - [Internet Archive - Classic PC Games](https://archive.org/details/classicpcgames) - Para jogos antigos.
-- [The Collection Chamber](https://collectionchamber.blogspot.com) - Para jogos antigos, melhorados para funcionar em sistemas modernos.
 - [Old-Games.RU](https://www.old-games.ru/catalog/) - Para jogos antigos. Pode ser trocado para inglês no canto superior direito.
 - [Wendy's Forum](https://wendysforum.net/index.php?action=forum) - Para HOGs. Registro requerido.
 - [DOS Games Archive](https://www.dosgamesarchive.com) - Para jogos de MS-DOS.
@@ -48,7 +47,7 @@ Você precisará duma VPN para torrentear com segurança e evitar avisos de copy
 - [🌟 RuTracker](https://rutracker.org/forum/index.php?c=19) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rutor](http://rutor.info/games) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
 - [Rustorka](https://rustorka.com/forum/index.php?c=6) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Tapochek](https://tapochek.net/index.php?c=2) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
+- [Tapochek](https://tapochek.net/index.php?c=2) - Registro requerido Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
 - [NMac](https://nmac.to/category/games) - Para aplicativos e jogos de macOS.
 - [Mac Torrents](https://www.torrentmac.net/category/games) - Para aplicativos e jogos de macOS.
 - [Mac Torrent](https://www.mactorrents.is/macos-games) - Para aplicativos e jogos de macOS.
@@ -58,23 +57,24 @@ Repacks são jogos compactados para usuários com pouca largura de banda, mas os
 
 - [🌟 DODI Repacks](https://dodi-repacks.site)
 - [🌟 FitGirl Repacks](https://fitgirl-repacks.site)
-- [Chovka](https://repack.info)
-- [Darck Repacks](https://darckrepacks.com)
-- [ElAmigos](https://elamigos.site) - Transferências lentas para usuários grátis. Use os espelhos do GLOAD ou Ova Games em vez disso.
+- [🌟 ElAmigos](https://elamigos.site) - Transferências lentas para usyários grátis. Use os espelhos do GLOAD ou Ova Games em vez disso.
+- [🌟 KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [FluxyRepacks](https://www.fluxycrack.fr/cracks%20jeux%201.html) - Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- RG Mechanics
 - [Xatab](https://otxatabs.net)
+- [Darck Repacks](https://darckrepacks.com)
+- [Chovka](https://repack.info)
 - Masquerade Repacks (mudou-se para o KaOsKrew)
-- Mr DJ
-- R.G. Catalyst
-- R.G. Mechanics
-- R.G. Revenants
-- ZAZIX
+- [Tiny Repacks](https://www.tiny-repacks.win)
+- [ZAZIX](https://1337x.to/user/ZAZIX/)
 - [Gnarly Repacks](https://gnarly-repacks.site) - Para jogos de console emulados.
-- [KAPITALSIN](https://kapitalsin.com/forum) - Para repacks com perdas (com arquivos de menor qualidade e/ou removidos). Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
-- [Tiny Repacks](https://www.tiny-repacks.win) - Para jogos indie.
+- [KAPITALSIN](https://kapitalsin.com/forum) - Para repacks com perdas (de menor qualidade e/ou com arquivos removidos). Use [um tradutor](https://github.com/FilipePS/Traduzir-paginas-web).
 - [M4CKD0GE Repacks](https://m4ckd0ge-repacks.site)
+- R.G. Catalyst
+- R.G. Revenants
+- Mr DJ
 - [MagiPack Games](https://www.magipack.games) - Para jogos antigos.
+- [The Collection Chamber](https://collectionchamber.blogspot.com) - Para jogos antigos.
 - [CPG Repacks](https://cpgrepacks.site) - Para jogos de anime +18.
 
 ### Trainers (Trapaças)
@@ -106,16 +106,16 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [🌟 Vimm's Lair](https://vimm.net/?p=vault)
 - [🌟 CDRomance](https://cdromance.com)
 - [Edge Emulation](https://edgeemu.net)
-- [ROMSPURE](https://romspure.cc)
 - [The ROM Depot](https://theromdepot.com) - Registro requerido.
+- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Siga [este guia](https://www.reddit.com/120c0du) para baixar.
+- [NoPayStation](https://nopaystation.com) - Para jogos de PlayStation 3, Portable e Vita.
 - [Ziperto](https://www.ziperto.com) - Para jogos de Nintendo Switch e 3DS.
 - [NXBrew](https://nxbrew.com) - Para jogos de Nintendo Switch.
 - [r/Roms](https://www.reddit.com/r/roms)
-- [Emuparadise](https://www.emuparadise.me/roms-isos-games.php) - Siga [este guia](https://www.reddit.com/120c0du) para baixar.
 
 ### Gerenciadores de Transferências
 
-- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detecta links da maioria dos hospedeiros de arquivos. Siga [este guia](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/jdownloader2.md#configuration) para o melhorar. Evite mais CAPTCHAs com o [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). Veja [isto](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) para um tema escuro.
+- [🌟 JDownloader2](https://jdownloader.org/jdownloader2) - Detecta links da maioria dos hospedeiros de arquivos. Siga [este guia](https://www.reddit.com/r/PiratedGames/comments/12axfj3/how_to_enhance_jdownloader2) para o melhorar. Evite mais CAPTCHAs com o [Offline CAPTCHA Solver](https://github.com/cracker0dks/CaptchaSolver). Veja [isto](https://support.jdownloader.org/Knowledgebase/Article/View/dark-mode-theme) para um tema escuro.
 - [Motrix](https://motrix.app)
 - [Free Download Manager](https://www.freedownloadmanager.org) - Use o [Elephant](https://github.com/meowcateatrat/elephant) para baixar vídeos.
 - [Internet Download Manager](https://internetdownloadmanager.com) -  O [IDMHelper](https://github.com/unamer/IDMHelper) é recomendado. Use o [IDM Trial Reset](https://github.com/J2TEAM/idm-trial-reset) para o usar para sempre.
@@ -157,9 +157,9 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 - [RetroArch](https://retroarch.com) - Para jogos de vários consoles.
 - [Ryujinx](https://ryujinx.org) - Para jogos de Nintendo Switch.
 - [yuzu](https://yuzu-emu.org) - Para jogos de Nintendo Switch.
-- [Cemu](https://cemu.info) - Para jogos de Nintendo Wii U.
+- [Cemu](https://cemu.info) - Para jogos de Wii U.
 - [Citra](https://citra-emu.org) - Para jogos de Nintendo 3DS.
-- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos de Nintendo Wii e GameCube.
+- [Dolphin Emulator](https://dolphin-emu.org) - Para jogos de Wii e GameCube.
 - [RCPS3](https://rpcs3.net) - Para jogos de PlayStation 3.
 - [xenia](https://xenia.jp) - Para jogos de Xbox 360.
 - [MAME](https://www.mamedev.org) - Para jogos de arcade.
@@ -190,7 +190,7 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 
 ### Extensões de Navegador Úteis
 
-- [uBlock Origin](https://ublockorigin.com) - Bloqueador de conteúdo de anúncio. Seguir as [recomendações do Privacy Guides](https://www.privacyguides.org/en/desktop-browsers/#ublock-origin) é recomendado.
+- [uBlock Origin](https://ublockorigin.com) - Bloqueador de conteúdo de anúncio. Seguir as [recomendações do Privacy Guides](https://www.privacyguides.org/desktop-browsers/#ublock-origin) é recomendado.
 - [FastForward](https://fastforward.team) - Contornador de encurtadores de links.
 - [AdNauseam](https://adnauseam.io) - Bloqueador de conteúdo de anúncio baseado no uBlock Origin que também ofusca os dados de navegação.
 
@@ -215,6 +215,7 @@ Sem transferências fornecidas. Os sites têm informações de lançamentos da c
 Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Software](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw) para bloquear a maioria dos sites mencionados aqui e mais. Siga [este guia](https://www.reddit.com/125a5xb) para adicionar o filtro customizado ao uBlock Origin.
 
 > :warning: **GRUPOS DA CENA NÃO TÊM SITES! Todo site com o nome dum grupo da cena na URL é falso.**
+
 - AGFY - Anúncios de redirecionamento maliciosos.
 - AimHaven - Anúncios de redirecionamento maliciosos.
 - AllTorrents
@@ -227,7 +228,7 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 - Game3rb
 - Games Releaser
 - GOG Unlocked/SteamUnlocked - Jogos roubados da IGG Games e nosTEAM, anúncios de redirecionamento maliciosos e transferências lentas.
-- IGG Games/PCGamesTorrents - Fez doxing com o mercs213 (dono do Good Old Downloads), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
+- IGG Games/PCGamesTorrents - Fez doxing com o mercs213 (dono do GOG Games), explora-lhe por receita de anúncios e põe a própria DRM em jogos indie.
 - MrPcGames
 - NexusGames - Pego com malware.
 - nosTEAM
@@ -248,10 +249,10 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 - Avast - Conhecida por vender dados dos usuários.
 - AVG/CCleaner - Propriedade da Avast.
 - BitComet/Bittorent - Adware.
-- BitLord - Adware.
+- BitLord - [Adware](https://www.virustotal.com/gui/file/3ad1aed8bd704152157ac92afed1c51e60f205fbdce1365bad8eb9b3a69544d0).
 - CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Propriedade](https://rentry.co/i8dwr) da [Kape](https://reddit.com/q3lepv).
-- FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
-- GShade - [Reinicia](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
+- FrostWire - [Adware](https://www.virustotal.com/gui/file/f20d66b647f15a5cd5f590b3065a1ef2bcd9dad307478437766640f16d416bbf/detection).
+- GShade - [Reinicia](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
 - McAfee - Instala bloatware.
-- PolyMC - O dono [expulsou todos os membros](https://reddit.com/y6lt6s) do servidor do Discord e repositório.
-- TLauncher - Práticas comerciais [questionáveis](https://reddit.com/zmzzrt).
+- PolyMC - O dono [expulsou todos os membros](https://www.reddit.com/y6lt6s) do servidor do Discord e repositório.
+- TLauncher - Práticas comerciais [questionáveis](https://www.reddit.com/zmzzrt).

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -8,7 +8,7 @@ Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas
 - [XNA Framework](https://www.microsoft.com/download/details.aspx?id=20914)
 
 ### Sites de Transferências Diretas
-Transferências diretas são transferências normais por um servidor, sendo mais seguras e não exigindo uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
+Transferências diretas são transferências normais por um servidor, sendo mais seguras e não exigindo uma VPN. Você deve precisar duma VPN para acessar sites de hospedagem de arquivos (por exemplo, Rapidgator nalguns países da UE). Veja a [seção de gerenciadores de transferências](#gerenciadores-de-transferências) para ajuda no gerenciamento de suas transferências.
 
 - [🌟 CS.RIN.RU](https://cs.rin.ru/forum)
   - O [CS.RIN.RU Enhanced](https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod) é recomendado.
@@ -73,7 +73,7 @@ Transferências diretas são transferências normais por um servidor, sendo mais
   - Registro requerido.
 
 ### Sites de Torrents
-Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a [seção de VPNs](https://github.com/r-piratedgames/megathread/blob/master/translations/README_PT-BR.md#vpns) para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.
+Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a [seção de VPNs](#vpns) para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.
 
 - [🌟 1337x](https://1337x.to/sub/10/0/)
   - Evite torrents da IGG Games.

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -244,15 +244,15 @@ Vocẽ pode só usar o filtro de bloqueador de anúncios [FMHY Unsafe Sites/Soft
 
 ### Programas Inseguros
 
-- μTorrent - Tem [anúncios e tastreadores e é inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
+- μTorrent - Tem anúncios e rastreadores e é [inseguro](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware).
 - Avast - Conhecida por venser dados dos usuários.
 - AVG/CCleaner - Propriedade da Avast.
 - BitComet/Bittorent - Adware.
 - BitLord - Adware.
 - CyberGhost/ExpressVPN/Private Internet Access/ZenMate - [Propriedade](https://rentry.co/i8dwr) da [Kape](https://reddit.com/q3lepv).
 - FrostWire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd).
-- GShade - [Reinicia seu computador ao usar aplicativos de atualização de terceiros](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt).
+- GShade - [Reinicia](https://reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/j7vx9vt) seu computador ao usar aplicativos de atualização de terceiros.
 - McAfee - Instala bloatware.
-- now.gg - Rouba contas.
-- PolyMC - Owner [kicked all members](https://reddit.com/y6lt6s) from Discord server and repository.
+- now.gg - [Rouba](https://reddit.com/qu3j5q) contas.
+- PolyMC - Dono [expulsou tooos os membros](https://reddit.com/y6lt6s) do servidor do Discord e repositório.
 - TLauncher - Práticas comerciais [questionáveis](https://reddit.com/zmzzrt).


### PR DESCRIPTION
It turns out that the 1337x link was not working because I removed the slash (the last character of the URL) in the URL...

Anyway, I have a bunch of ideas, but I am afraid that I may be trying to bite more than I can chew and I need your help:
- Can I change the Brazilian Portuguese translation in this PR too or should I make another PR?
- Given the monstruosity (in a good way) of Koalageddon (EA Desktop, Epic Games Store, Origin, Steam and Uplay DLC unlocker) and DreamAPI (EA Desktop, Epic Games Store and Origin DLC unlocker), should I remove the other ones, that can only do part of the work that both do?
- Is separating macOS gaming and GNU/Linux gaming from the regular sites a good idea? How about separating Android gaming too?
- Should EA Desktop and Origin be called exactly like this or simply "EA clients"?
- Should I include sources for why the untrusted stuff is there? If I should, should the Reddit links be "reddit.com" or "old.reddit.com"?
- Should I include stuff other than game sites under "Untrusted Sites and Uploaders"? It bothers me how "Unstrusted software" also has gaming-related stuff but "Untrusted Sites and Uploaders" has gaming-only stuff.
- What do you think of adding [Free Linux PC Games](https://freelinuxpcgames.com) (that name screams malware lol) to the megathread? It is recommended by the r/FREEMEDIAHECKYEAH megathread, but their recommendations of ROMs sites kind of suck and some site names are wrong. Anyway, I have taken a look at the site and they state that their games are always taken from external sources (maybe RuTracker, as it has, besides the hopefully-not-extinct-but-I-am-not-so-sure Torrminatorr Forum, the biggest number of GNU/Linux games), but they always verify the files before uploading.