### PR TITLE
Reflect Torrminatorr's Comeback and Change G4U's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - Google Drive and torrent
   - 1+ day on [their Discord server](https://discord.com/invite/bzJkrxXXR2) unlocks Google Drive links.
 - [GameDrive](https://gamedrive.org)
-- [G4U](https://g4u.to)
+- [Torrminatorr](https://forum.torrminatorr.com)
+  - GOG, Linux games and scene releases
+  - Registration required.
+- [Games 4 You](https://g4u.to)
   - Slow downloads for free users.
   - Password: `404`
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game)
@@ -67,9 +70,6 @@ Direct downloads are normal downloads from a server, being safer and not requiri
   - MS-DOS games
 - [PollyMC](https://github.com/fn2006/PollyMC)
   - Minecraft
-- [Torrminatorr Forum [Offline Currently]](https://forum.torrminatorr.com)
-  - GOG, Linux games and scene releases
-  - Registration required.
 
 ### Torrent Sites
 Torrents are P2P downloads from other users, without servers. You will need a VPN to torrent safely and avoid ISP copyright notices, unless your country tolerates piracy. Check the [VPNs section](#vpns) for more info.

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -1,4 +1,4 @@
-## **Aqui Está a Megathread do /r/PiratedGames** - [Traduções](./translations/)
+## **Aqui Está a Megathread do /r/PiratedGames!** - [Traduções](./translations/)
 
 ### Componentes Requeridos
 Instale tudo antes de baixar jogos (legítimos ou pirateados) para evitar falhas devido a programas faltando no seu computador.

--- a/translations/README_PT-BR.md
+++ b/translations/README_PT-BR.md
@@ -30,7 +30,10 @@ Transferências diretas são transferências normais por um servidor, sendo mais
   - Google Drive e torrent
   - 1+ dia no [servidor do Discord deles](https://discord.com/invite/bzJkrxXXR2) desbloqueia os links do Google Drive.
 - [GameDrive](https://gamedrive.org)
-- [G4U](https://g4u.to)
+- [Torrminatorr](https://forum.torrminatorr.com)
+  - Jogos de GOG e Linux e lançamentos da Cena
+  - Registro requerido.
+- [Games 4 You](https://g4u.to)
   - Transferências lentas para usuários grátis.
   - Senha: `404`
 - [Downloadha](https://www.downloadha.com/category/%D8%A8%D8%A7%D8%B2%DB%8C-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1-pc-computer-game)
@@ -67,9 +70,7 @@ Transferências diretas são transferências normais por um servidor, sendo mais
   - Jogos de MS-DOS
 - [PollyMC](https://github.com/fn2006/PollyMC)
   - Minecraft
-- [Torrminatorr Forum [Offline Atualmente]](https://forum.torrminatorr.com)
-  - Jogos de GOG e Linux e lançamentos da Cena
-  - Registro requerido.
+
 
 ### Sites de Torrents
 Você precisará duma VPN para torrentear com segurança e evitar avisos de copyright do seu provedor, a menos que seu país tolere pirataria. Veja a [seção de VPNs](#vpns) para mais informações. Torrents são transferências P2P doutros usuários, sem servidores.


### PR DESCRIPTION
Now that Torrminatorr is back, where do you think it should be? I have moved it to somewhere between Games 4 You and GameDrive, but I have not taken a good look at it.

Also, “G4U” is apparently called “games 4 you”, but I refuse to not use any capitalized letters on it, so I have put “Games 4 You”. Are you ok with that?